### PR TITLE
perf: default streaming on + parallel_tool_calls for chat completions

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -250,6 +250,8 @@ class ChatCompletionsTransport(ProviderTransport):
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools
+            if not params.get("is_lmstudio", False):
+                api_kwargs["parallel_tool_calls"] = True
 
         # max_tokens resolution — priority: ephemeral > user > provider default
         max_tokens_fn = params.get("max_tokens_param_fn")
@@ -438,6 +440,8 @@ class ChatCompletionsTransport(ProviderTransport):
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools
+            if not params.get("is_lmstudio", False):
+                api_kwargs["parallel_tool_calls"] = True
 
         # max_tokens resolution — priority: ephemeral > user > profile default
         max_tokens_fn = params.get("max_tokens_param_fn")

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -348,7 +348,7 @@ DEFAULT_STREAMING_CURSOR: str = " ▉"
 @dataclass
 class StreamingConfig:
     """Configuration for real-time token streaming to messaging platforms."""
-    enabled: bool = False
+    enabled: bool = True
     # Transport selection:
     #   "auto"  — prefer native streaming-draft updates when the platform
     #             supports them (Telegram sendMessageDraft, Bot API 9.5+);


### PR DESCRIPTION
## Summary

Two minimal speed wins for Hermes2 latency on Discord/Slack/Telegram:

- **Streaming default on** — `StreamingConfig.enabled` defaults to `True`. Discord (and any platform with edit-based or native-draft streaming) now sees response tokens arrive progressively instead of as a single final edit. Cuts time-to-first-visible-text from \"full response latency\" to \"first token latency\".
- **`parallel_tool_calls=True` on Chat Completions** — `ChatCompletionsTransport._build_kwargs_from_legacy` and `_build_kwargs_from_profile` now set `parallel_tool_calls=True` whenever `tools` are supplied (skipping LM Studio, which rejects the kwarg). DeepSeek, OpenRouter, OpenAI and Kimi can now fan out independent tool calls in a single round instead of serializing them across multiple turns.

Mirrored to live runtime: `~/.hermes2/config.yaml` `streaming.enabled` flipped to `true`, and the sibling clone at `~/.hermes2/hermes-agent` got the same patches. Gateway restarted (`launchctl kickstart -k gui/501/ai.hermes2.gateway`) and Discord reconnected cleanly.

Existing capabilities that already help speed and are unchanged:
- `display.streaming: true` (already on)
- `prompt_caching.long_lived_prefix: true` w/ `long_lived_ttl: 1h` (already on)
- `openrouter.response_cache: true` (already on)
- `human_delay.mode: off` (already off)
- Discord `send_typing` already invoked while processing

## Test plan

- [x] `gateway/config.py` imports clean, `StreamingConfig().enabled` is `True`
- [x] `agent/transports/chat_completions.py` parses (`ast.parse`)
- [x] Gateway restarts cleanly and Discord reconnects
- [ ] Send a Discord message; verify response tokens arrive progressively
- [ ] Trigger a multi-tool turn; verify `parallel_tool_calls=true` in request payload (OpenRouter dashboard or `tcpdump`/log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)