### PR TITLE
fix(agent): remove duplicate AIAgent class declaration causing AttributeError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.13.0"
+version = "0.13.1"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/run_agent.py
+++ b/run_agent.py
@@ -1157,7 +1157,6 @@ class AIAgent:
         self._base_url_lower = value.lower() if value else ""
         self._base_url_hostname = base_url_hostname(value)
 
-class AIAgent:
     def __init__(self,
         # Context retention enhancements
         conversation_context: dict = None,  # Persistent context dictionary


### PR DESCRIPTION
## Problem

Gateway crashed on **every** Discord/Slack/Telegram message with:

```
AttributeError: type object 'AIAgent' has no attribute '_TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER'
  File "run_agent.py", line 10468, in _sanitize_tool_call_arguments
    marker = AIAgent._TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER
```

100% of agent conversations failed — the runtime tool-call sanitizer reaches `AIAgent._TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER` on every iteration.

## Root cause

Commit `f7898d83` (`feat: Add context retention system with persistent storage`) intended to add three new kwargs to `AIAgent.__init__`. The diff accidentally replaced:

```python
    def __init__(
        self,
```

with:

```python
class AIAgent:
    def __init__(self,
        # Context retention enhancements
        conversation_context: dict = None,
        context_ttl: int = 3600,
        proactive_check_interval: int = 300,
        # Original params below
```

That created a **second** `class AIAgent:` declaration immediately below the first one. Python keeps only the last binding for a name at module scope, so the second class silently shadowed the first — discarding the docstring, the `_TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER` class attribute, and the `base_url` property/setter.

## Fix

Drop the duplicate `class AIAgent:` line and re-indent `__init__` back into the original class body. Context-retention kwargs are preserved.

```mermaid
classDiagram
    class Before_BROKEN {
        <<module: run_agent.py>>
    }
    class AIAgent_first_1137 {
        <<class AIAgent at line 1137>>
        +_TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER
        +base_url property
        +base_url setter
    }
    class AIAgent_second_1160_shadows {
        <<class AIAgent at line 1160 — wins>>
        +__init__()
        +run_conversation()
        +_sanitize_tool_call_arguments()  -- references missing marker
    }
    Before_BROKEN --> AIAgent_first_1137 : defined first, discarded
    Before_BROKEN --> AIAgent_second_1160_shadows : final binding at runtime

    class After_FIXED {
        <<module: run_agent.py>>
    }
    class AIAgent_single_1137 {
        <<class AIAgent at line 1137 — single>>
        +_TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER
        +base_url property
        +base_url setter
        +__init__(conversation_context, context_ttl, ...)
        +run_conversation()
        +_sanitize_tool_call_arguments()  -- marker resolves
    }
    After_FIXED --> AIAgent_single_1137 : sole definition
```

Files changed:

- ` run_agent.py` — drop duplicate \`class AIAgent:\` line, re-indent \`__init__\`
- ` pyproject.toml` — bump \`0.13.0\` → \`0.13.1\` (SemVer patch)

## Tests

- **Static**: \`python3 -m ast\` parses cleanly; \`grep -n '^class AIAgent' run_agent.py\` returns exactly one hit (\`1137\`).
- **Runtime introspection** via gateway venv:
  ```
  $ ./venv/bin/python -c "import run_agent, inspect; \
      print(inspect.getsourcelines(run_agent.AIAgent)[1]); \
      print(hasattr(run_agent.AIAgent, '_TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER'))"
  1137
  True
  ```
- **Live gateway** (\`launchctl kickstart -k gui/501/ai.hermes2.gateway\`): \`gateway.err.log\` truncated post-restart, no \`AttributeError\` 30s+ later. Discord traffic resumes normally.