### PR TITLE
chore: add long-running AI agent playbook scaffolding

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,9 @@
+instructions = "AGENTS.md"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+[features]
+goals = true
+
+[sandbox_workspace_write]
+network_access = true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,50 @@
+# Autonomous Coding Instructions
+
+You are an autonomous coding agent.
+
+## Read First
+
+- PRD.md
+- PROGRESS.md
+- README.md
+- AGENTS.md
+- tests
+- project/package files
+
+## Work Loop
+
+1. Pick the next incomplete task.
+2. Implement the smallest safe change.
+3. Run validation.
+4. Fix failures.
+5. Update PROGRESS.md.
+6. Continue until complete.
+
+## Do Not
+
+- rewrite unrelated architecture
+- remove tests
+- fake successful validation
+- push without explicit instruction
+- expose secrets
+- modify production credentials
+
+## Complete Only When
+
+- PRD.md is fully done
+- tests/build/lint pass
+- GOAL_RESULT.md is written
+
+<!-- codex-long-running-agent-overlay:start -->
+## Universal Long-Running Agent Overlay
+
+This section complements the repository-specific guidance already in this file. If anything here conflicts with the repo-specific rules above, the repo-specific rules win.
+
+- `PRD.md` is the task source of truth for long-running sessions.
+- `PROGRESS.md` is the persistent checkpoint log.
+- `GOAL_RESULT.md` is the final execution report.
+- Before coding, read this file, `PRD.md`, `PROGRESS.md` when it exists, `README.md`, project manifests, tests, and the relevant source folders.
+- Work in small checkpoints, run the smallest relevant validation after each meaningful change, update `PROGRESS.md`, and continue until complete or genuinely blocked.
+- Stop only when the requested work is complete, validation is documented, and `GOAL_RESULT.md` reflects the outcome.
+- Do not rewrite unrelated architecture, fake successful validation, expose secrets, or push without explicit operator instruction for the active session.
+<!-- codex-long-running-agent-overlay:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1100,3 +1100,17 @@ not the specific names.
 
 Reviewers should reject new change-detector tests; authors should convert
 them into invariants before re-requesting review.
+
+<!-- codex-long-running-agent-overlay:start -->
+## Universal Long-Running Agent Overlay
+
+This section complements the repository-specific guidance already in this file. If anything here conflicts with the repo-specific rules above, the repo-specific rules win.
+
+- `PRD.md` is the task source of truth for long-running sessions.
+- `PROGRESS.md` is the persistent checkpoint log.
+- `GOAL_RESULT.md` is the final execution report.
+- Before coding, read this file, `PRD.md`, `PROGRESS.md` when it exists, `README.md`, project manifests, tests, and the relevant source folders.
+- Work in small checkpoints, run the smallest relevant validation after each meaningful change, update `PROGRESS.md`, and continue until complete or genuinely blocked.
+- Stop only when the requested work is complete, validation is documented, and `GOAL_RESULT.md` reflects the outcome.
+- Do not rewrite unrelated architecture, fake successful validation, expose secrets, or push without explicit operator instruction for the active session.
+<!-- codex-long-running-agent-overlay:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# Claude Code Long-Running Agent Rules
+
+## Role
+
+You are a long-running autonomous coding agent working inside this repository.
+
+## Main Files
+
+- PRD.md: source of truth
+- PROGRESS.md: running memory
+- GOAL_RESULT.md: final report
+- AGENTS.md: shared agent rules
+
+## Required Reading
+
+Before coding, read:
+
+1. CLAUDE.md
+2. AGENTS.md
+3. PRD.md
+4. PROGRESS.md, if it exists
+5. README.md
+6. package/project files
+7. tests
+8. relevant source folders
+
+## Loop Behavior
+
+Keep working until the PRD is complete or a real blocker is found.
+
+Each loop must:
+
+1. Read current progress.
+2. Pick the next smallest task.
+3. Implement.
+4. Validate.
+5. Fix failures.
+6. Update PROGRESS.md.
+7. Continue.
+
+## Rules
+
+- Do not rewrite unrelated architecture.
+- Do not delete files without documenting why.
+- Do not push to remote.
+- Do not fake passing tests.
+- Do not expose secrets.
+- Do not modify production credentials.
+- Prefer small, reviewable changes.
+- Add or update tests when behavior changes.
+
+## Permission Mode
+
+Use acceptEdits or auto for normal projects.
+Use bypassPermissions only inside Docker, VM, or disposable workspace.
+
+## Done Means
+
+- Feature implemented.
+- Tests/build/lint pass.
+- Progress documented.
+- GOAL_RESULT.md written.
+
+<!-- codex-long-running-agent-overlay:start -->
+## Universal Long-Running Agent Overlay
+
+This section complements the repository-specific guidance already in this file. If anything here conflicts with the repo-specific rules above, the repo-specific rules win.
+
+- `PRD.md` is the task source of truth for long-running sessions.
+- `PROGRESS.md` is the persistent checkpoint log.
+- `GOAL_RESULT.md` is the final execution report.
+- Before coding, read this file, `PRD.md`, `PROGRESS.md` when it exists, `README.md`, project manifests, tests, and the relevant source folders.
+- Work in small checkpoints, run the smallest relevant validation after each meaningful change, update `PROGRESS.md`, and continue until complete or genuinely blocked.
+- Stop only when the requested work is complete, validation is documented, and `GOAL_RESULT.md` reflects the outcome.
+- Do not rewrite unrelated architecture, fake successful validation, expose secrets, or push without explicit operator instruction for the active session.
+<!-- codex-long-running-agent-overlay:end -->

--- a/GOAL_RESULT.md
+++ b/GOAL_RESULT.md
@@ -1,0 +1,46 @@
+# Goal Result
+
+## Summary
+
+Describe what was completed.
+
+## Changed Files
+
+- file 1
+- file 2
+
+## Validation Commands
+
+```bash
+command here
+```
+
+## Validation Results
+
+- build: pass/fail
+- tests: pass/fail
+- lint: pass/fail
+
+## Remaining Risks
+
+- risk 1
+- risk 2
+
+## Suggested PR Title
+
+`feat: implement ...`
+
+## Suggested PR Body
+
+```md
+## Summary
+- ...
+
+## Validation
+- [x] tests
+- [x] build
+- [x] lint
+
+## Risks
+- ...
+```

--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,60 @@
+# PRD - Feature Name
+
+## Objective
+
+Describe exactly what must be implemented.
+
+## Context
+
+Explain the repository, current behavior, and desired behavior.
+
+## Requirements
+
+- [ ] Requirement 1
+- [ ] Requirement 2
+- [ ] Requirement 3
+
+## Non-Goals
+
+The agent must not:
+
+- rewrite unrelated modules
+- change unrelated APIs
+- introduce large dependencies without need
+- remove tests
+
+## Technical Notes
+
+Relevant files/folders:
+
+```text
+src/
+tests/
+README.md
+package.json
+```
+
+## Validation Commands
+
+Run the available commands:
+
+```bash
+npm test
+npm run build
+npm run lint
+```
+
+Or for .NET:
+
+```bash
+dotnet test
+dotnet build
+```
+
+## Done When
+
+- [ ] All requirements are implemented
+- [ ] Tests pass
+- [ ] Build passes
+- [ ] Lint/typecheck passes, when available
+- [ ] GOAL_RESULT.md is written

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,29 @@
+# Progress Log
+
+## Current Status
+
+Not started.
+
+## Checkpoints
+
+### Checkpoint 1
+
+Status: pending
+
+Task:
+
+Result:
+
+Validation:
+
+Next:
+
+## Blockers
+
+None.
+
+## Validation History
+
+| Command | Result | Notes |
+|---|---|---|
+| | | |


### PR DESCRIPTION
        Closes #59

## Summary
        - add the long-running AI agent playbook scaffolding files
        - append a universal overlay to the existing agent instruction files
        - keep the repository-specific guidance intact

        ## Validation
        - `taskflow inspect /var/folders/4w/3kxdvh6s4ts7rw5h21rk3xr40000gn/T/codex-playbook-z4sf9dif/repo (ok)`
- `taskflow run /var/folders/4w/3kxdvh6s4ts7rw5h21rk3xr40000gn/T/codex-playbook-z4sf9dif/repo (ok)`

        ## Notes
        - no version bump was applied because this is repository-internal agent scaffolding
        - no existing instruction file was replaced; the change is additive
