### PR TITLE
fix(sprint-1): address Copilot review on PR #61 + sync backlog with upstream merge

### DIFF
--- a/agent/auto_mapper.py
+++ b/agent/auto_mapper.py
@@ -143,7 +143,6 @@ def maybe_map_project(cwd: str | Path | None = None) -> dict[str, object]:
         logger.warning("Auto-mapper subprocess failed: %s", exc)
         return {"ran": False, "reason": f"spawn-error:{exc}", "result": None}
 
-    _AUTO_MAP_DONE.add(project_root)
     parsed: dict | None = None
     if result.stdout:
         try:
@@ -152,11 +151,34 @@ def maybe_map_project(cwd: str | Path | None = None) -> dict[str, object]:
             parsed = json.loads(result.stdout)
         except (ValueError, TypeError):
             parsed = None
+
+    # Only mark this project as "done for the session" if the mapper actually
+    # succeeded.  A non-zero exit or an ``ok: false`` payload means the next
+    # invocation within the same process should try again instead of silently
+    # skipping.  Closes Copilot review on PR #61.
+    success = result.returncode == 0 and (
+        parsed is None or parsed.get("ok") is True
+    )
+    if success:
+        _AUTO_MAP_DONE.add(project_root)
+        reason = "mapped"
+    else:
+        reason = f"mapper-failed:returncode={result.returncode}"
+        if parsed and parsed.get("error"):
+            reason = f"mapper-failed:{parsed['error']}"
+        logger.warning(
+            "Auto-mapper failed for %s: returncode=%s, parsed=%r",
+            project_root,
+            result.returncode,
+            parsed,
+        )
+
     return {
         "ran": True,
-        "reason": "mapped",
+        "reason": reason,
         "result": parsed,
         "returncode": result.returncode,
+        "ok": success,
     }
 
 

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -116,14 +116,14 @@ def hermes_lsp_bin_dir() -> Path:
     Resolution order: TOTA_HOME → HERMES_HOME (legacy) → ``~/.tota``.
     Matches :func:`hermes_constants.get_hermes_home` but inlined here
     because this module is in the LSP-install hot path and must stay
-    import-light.
+    import-light.  Env values are ``.strip()``'d so a stray
+    whitespace setting doesn't yield an invalid path (closes Copilot
+    review on PR #61).
     """
-    home = (
-        os.environ.get("TOTA_HOME")
-        or os.environ.get("HERMES_HOME")
-        or os.path.join(os.path.expanduser("~"), ".tota")
-    )
-    p = Path(home) / "lsp" / "bin"
+    tota = (os.environ.get("TOTA_HOME") or "").strip()
+    legacy = (os.environ.get("HERMES_HOME") or "").strip()
+    home = tota or legacy or os.path.join(os.path.expanduser("~"), ".tota")
+    p = Path(os.path.expanduser(home)) / "lsp" / "bin"
     p.mkdir(parents=True, exist_ok=True)
     return p
 

--- a/docs/SPRINT_BACKLOG.md
+++ b/docs/SPRINT_BACKLOG.md
@@ -21,25 +21,25 @@ codebase can find the plan without leaving their editor.
 - ✅ #27 — Bootstrap `.tota/` defaults into runtime `$TOTA_HOME` on first run (`agent/tota_home_bootstrap.py`).
 - ✅ #28 — Pytest coverage for the llm-project-mapper skill (23 cases).
 - ✅ #29 — Consolidate `HERMES_HOME` literal lookups behind `hermes_constants.get_hermes_home()`.
-- ⏳ #30 — Cherry-pick upstream cross-session 1h Claude prompt cache (Hermes #23828). Needs upstream commit identification.
-- ⏳ #31 — Cherry-pick upstream per-turn file-mutation verifier footer (Hermes #24498).
+- ✅ #30 — Cherry-pick upstream cross-session 1h Claude prompt cache (Hermes #23828) — landed via upstream merge `ab61ec254`; lives in `agent/prompt_caching.py`.
+- ✅ #31 — Cherry-pick upstream per-turn file-mutation verifier footer (Hermes #24498) — landed via upstream merge `ab61ec254`.
 - ✅ #32 — Decide `.github/workflows/lint.yml` fork-guard policy → `docs/adr/0002-lint-yml-fork-guard.md`.
 
 ## Sprint 2 — Performance wave alignment
 
-- ⏳ #33 — Cherry-pick 180x faster `browser_console` (Hermes #23226).
-- ⏳ #34 — Adopt upstream cold-start wave (~19s win).
+- ✅ #33 — Cherry-pick 180x faster `browser_console` (Hermes #23226) — landed via upstream merge `ab61ec254`.
+- ✅ #34 — Adopt upstream cold-start wave (~19s win) — landed via upstream merge `ab61ec254`.
 - ⏳ #35 — Phase 2 `msgspec.Struct` migration for `transports/types.py::ToolCall`. High-risk; needs dedicated PR.
 - ⏳ #36 — Phase 1.5 `run_agent.py` `orjson` migration. Needs per-site `strict=False` audit.
 - ⏳ #37 — Phase 1.5 `hermes_state.py` `orjson` migration + SQLite round-trip audit. Highest-risk; behind `TOTA_FAST_STATE=1` feature flag.
-- ⏳ #38 — Refresh `tota_agent_benchmark_report.pdf` post-merge.
+- ⏳ #38 — Refresh `tota_agent_benchmark_report.pdf` post-merge. Needs runtime benchmarking environment.
 
 ## Sprint 3 — Distribution + identity polish
 
 - ✅ #39 — PyPI publishing plan → `docs/adr/0001-pypi-publishing.md` (chose Option B: metapackage).
-- ⏳ #40 — Adopt upstream lazy-deps framework (Hermes #24220).
+- ✅ #40 — Adopt upstream lazy-deps framework (Hermes #24220) — landed via upstream merge + Wesley's `dceca21ea`.
 - ✅ #41 — Adopt supply-chain advisory checker for lazy installs (`hermes_cli/security_advisories.py` + `tools/lazy_deps.py` guard).
-- ⏳ #42 — Adopt tiered install fallback (Hermes #24515).
+- ✅ #42 — Adopt tiered install fallback (Hermes #24515) — landed via upstream merge.
 - ✅ #43 — Brand consistency pass (default + 4 neutral skins, CLI welcome banner, SOUL.md template).
 - ✅ #44 — `SOUL.md` override docs page (`docs/tota-identity-customization.md`).
 - ⏳ #45 — Native Windows beta integration test pass (40+ Windows fixes). Needs a Windows runner.
@@ -47,17 +47,21 @@ codebase can find the plan without leaving their editor.
 
 ## Sprint 4 — Features, skills, nice-to-have
 
-- 🚦 #55 — Security trio (land first) → `docs/adr/0003-security-trio-cherry-pick-plan.md` documents the cherry-pick plan.
-- ⏳ #47 — Local OpenAI-compatible proxy (Hermes #25969).
-- ⏳ #48 — `/handoff` live session transfer (Hermes #23395).
-- ⏳ #49 — `/subgoal` user controls (Hermes #25449).
-- ⏳ #50 — LSP semantic diagnostics on every write (Hermes #24168, #25978).
-- ⏳ #51 — `vision_analyze` raw pixels to vision models (Hermes #22955).
-- ⏳ #52 — `clarify` button UI on Telegram + Discord (Hermes #24199, #25485).
-- ⏳ #53 — OSC8 clickable URLs (Hermes #25071, #24013).
-- ⏳ #54 — Brave Search + DuckDuckGo web-search backends (Hermes #21337).
-- ⏳ #56 — Pull 4 new optional skills (hyperliquid, yahoo-finance, api-testing, watchers).
-- ⏳ #57 — (Stretch) `huggingface/skills` trusted default tap (Hermes #26219).
+- ✅ #55 — Security trio (Hermes #23736, #26829, #26823) — landed by Wesley via `9f16d52e4`, `8204a329c`, `0f3f23c19`.
+- ✅ #47 — Local OpenAI-compatible proxy (Hermes #25969) — landed via upstream merge `ab61ec254`.
+- ✅ #48 — `/handoff` live session transfer (Hermes #23395) — landed via upstream merge `ab61ec254`.
+- ✅ #49 — `/subgoal` user controls (Hermes #25449) — landed via upstream merge `ab61ec254`.
+- ✅ #50 — LSP semantic diagnostics on every write (Hermes #24168, #25978) — landed via upstream merge `ab61ec254`.
+- ✅ #51 — `vision_analyze` raw pixels to vision models (Hermes #22955) — landed via upstream merge `ab61ec254`.
+- ✅ #52 — `clarify` button UI on Telegram + Discord (Hermes #24199, #25485) — landed via upstream merge `ab61ec254`.
+- ✅ #53 — OSC8 clickable URLs (Hermes #25071, #24013) — landed via upstream merge `ab61ec254`; lives in `ui-tui/packages/hermes-ink/src/ink/hyperlinkHover.ts`.
+- ✅ #54 — Brave Search + DuckDuckGo web-search backends (Hermes #21337) — landed via upstream merge `ab61ec254`.
+- ✅ #56 — Pull 4 new optional skills — landed via upstream merge:
+  - `optional-skills/blockchain/hyperliquid`
+  - `optional-skills/finance/stocks` (yahoo-finance)
+  - `optional-skills/software-development/rest-graphql-debug` (api-testing)
+  - `optional-skills/devops/watchers`
+- ✅ #57 — huggingface/skills trusted default tap (Hermes #26219) — landed via upstream merge; see `tools/skills_guard.py:39` and `tools/skills_hub.py:332`.
 
 ## Status legend
 
@@ -71,3 +75,4 @@ codebase can find the plan without leaving their editor.
 - Cherry-picks are scoped tight: identify the upstream commit, apply, resolve conflicts preferring Tota's perf customizations + upstream's behavior, test.
 - Sprints are sequential. Each sprint's DoD must hold before the next sprint starts.
 - The `.tota/` repo directory is the source of truth for runtime defaults; `$TOTA_HOME` is the operator-mutable runtime home.
+- The upstream Hermes v0.14.0 merge (commit `ab61ec254`, 2026-05-18) closed 13 cherry-pick issues at once. Remaining open issues are local-only work (`msgspec` migration, `run_agent.py`/`hermes_state.py` `orjson` migration, benchmark refresh, Native Windows beta).

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -170,10 +170,15 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
     # signal-handler path stays import-light.
     try:
         # Resolution order: TOTA_HOME → HERMES_HOME (legacy) → no marker.
+        # Env values are stripped so a blank/whitespace setting doesn't probe
+        # an unintended relative directory (closes Copilot review on PR #61).
         # String literals kept so the signal-handler path stays import-light.
-        hermes_home_str = os.environ.get("TOTA_HOME") or os.environ.get("HERMES_HOME")
+        hermes_home_str = (
+            (os.environ.get("TOTA_HOME") or "").strip()
+            or (os.environ.get("HERMES_HOME") or "").strip()
+        )
         if hermes_home_str:
-            takeover_path = Path(hermes_home_str) / ".gateway-takeover.json"
+            takeover_path = Path(os.path.expanduser(hermes_home_str)) / ".gateway-takeover.json"
             if takeover_path.exists():
                 try:
                     raw = takeover_path.read_text(encoding="utf-8")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -253,24 +253,77 @@ except Exception:
 # under the repo's .tota/ tree (HERMES_BASE, version, memories/MEMORY.md,
 # mapped_projects.json). Idempotent and non-destructive — existing operator
 # files are never overwritten.
-try:
-    from agent.tota_home_bootstrap import bootstrap_tota_home as _bootstrap_tota_home
+#
+# Gating: only run the bootstrap and the auto-mapper for subcommands that
+# actually start an interactive agent session. Cheap utility subcommands
+# (`hermes --help`, `hermes --version`, `hermes config`, `hermes status`,
+# `hermes doctor`, `hermes logout`, `hermes update`, etc.) should stay
+# side-effect-free — no filesystem writes, no `npx` spawn. Closes Copilot
+# review on PR #61.
+_AGENT_SUBCOMMANDS = frozenset({
+    "chat",  # default interactive chat
+    "gateway",  # platform gateway
+    "cron",  # scheduled agent runs
+    "acp",  # editor integration agent
+    "kanban",  # multi-agent board
+    "send",  # one-shot send
+    "honcho",  # memory mode
+    "tui",  # ink TUI
+    "proxy",  # local OpenAI-compatible proxy
+})
 
-    _bootstrap_tota_home()
-except Exception:
-    pass  # best-effort — agent works fine without seed files
 
-# Tota-core directive: auto-invoke llm-project-mapper on first turn in any
-# code project. Idempotent across sessions (the mapper itself dedups via
-# $TOTA_HOME/mapped_projects.json) and within a session (auto_mapper dedups
-# per process). Disabled by TOTA_AUTO_MAP=0 or by a sentinel file in
-# $TOTA_HOME/.disable_auto_mapper.
-try:
-    from agent.auto_mapper import maybe_map_project as _maybe_map_project
+def _should_run_agent_side_effects() -> bool:
+    """Return True when the CLI invocation is going to start an agent.
 
-    _maybe_map_project()
-except Exception:
-    pass  # best-effort — agent works fine without the mapper
+    Bootstrap + auto-mapper are gated behind this so `hermes --help` and
+    other cheap-utility paths don't trigger filesystem writes or npx spawns.
+    Default: True (run them) unless we can clearly identify a cheap path.
+    Tota-set ``TOTA_SKIP_STARTUP_HOOKS=1`` forces a skip.
+    """
+    if (os.environ.get("TOTA_SKIP_STARTUP_HOOKS") or "").strip() in {"1", "true", "yes", "on"}:
+        return False
+    if len(sys.argv) <= 1:
+        return True  # bare `hermes` → interactive chat
+    first = sys.argv[1].lstrip("-").lower()
+    if first in {"help", "version", "h", "v"}:
+        return False
+    if first in _AGENT_SUBCOMMANDS:
+        return True
+    # Unknown / cheap subcommands (config, status, doctor, logout, update,
+    # tools, skills, profile, model, debug, dump, plugins, version, etc.)
+    # default to "no side effects" — these don't run an agent.
+    _CHEAP_SUBCOMMANDS = frozenset({
+        "config", "status", "doctor", "logout", "update", "uninstall",
+        "tools", "skills", "profile", "model", "debug", "dump",
+        "plugins", "version", "logs", "curator", "webhook",
+    })
+    if first in _CHEAP_SUBCOMMANDS:
+        return False
+    # Default to True for unrecognised inputs — better to run the hooks
+    # than to silently skip them on a new subcommand.
+    return True
+
+
+if _should_run_agent_side_effects():
+    try:
+        from agent.tota_home_bootstrap import bootstrap_tota_home as _bootstrap_tota_home
+
+        _bootstrap_tota_home()
+    except Exception:
+        pass  # best-effort — agent works fine without seed files
+
+    # Tota-core directive: auto-invoke llm-project-mapper on first turn in
+    # any code project. Idempotent across sessions (the mapper itself
+    # dedups via $TOTA_HOME/mapped_projects.json) and within a session
+    # (auto_mapper dedups per process). Disabled by TOTA_AUTO_MAP=0 or by
+    # a sentinel file in $TOTA_HOME/.disable_auto_mapper.
+    try:
+        from agent.auto_mapper import maybe_map_project as _maybe_map_project
+
+        _maybe_map_project()
+    except Exception:
+        pass  # best-effort — agent works fine without the mapper
 
 # Apply IPv4 preference early, before any HTTP clients are created.
 try:

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -59,19 +59,28 @@ except ImportError:
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _resolve_tota_home_fallback() -> Path:
+    """Mirror hermes_constants.get_hermes_home() with stripped env values.
+
+    Used when ``hermes_constants`` can't be imported.  Strips whitespace so
+    a blank/whitespace setting doesn't yield an unintended path (closes
+    Copilot review on PR #61).
+    """
+    tota = (os.environ.get("TOTA_HOME") or "").strip()
+    legacy = (os.environ.get("HERMES_HOME") or "").strip()
+    raw = tota or legacy
+    if raw:
+        return Path(os.path.expanduser(raw))
+    return Path.home() / ".tota"
+
+
 def _get_sessions_dir() -> Path:
     """Return the sessions directory using HERMES_HOME."""
     try:
         from hermes_constants import get_hermes_home
         return get_hermes_home() / "sessions"
     except ImportError:
-        # Fallback only fires when hermes_constants can't be imported.
-        # Mirror the constants module's resolution order: TOTA_HOME → HERMES_HOME → ~/.tota.
-        return Path(
-            os.environ.get("TOTA_HOME")
-            or os.environ.get("HERMES_HOME")
-            or Path.home() / ".tota"
-        ) / "sessions"
+        return _resolve_tota_home_fallback() / "sessions"
 
 
 def _get_session_db():
@@ -107,11 +116,7 @@ def _load_channel_directory() -> dict:
         from hermes_constants import get_hermes_home
         directory_file = get_hermes_home() / "channel_directory.json"
     except ImportError:
-        directory_file = Path(
-            os.environ.get("TOTA_HOME")
-            or os.environ.get("HERMES_HOME")
-            or Path.home() / ".tota"
-        ) / "channel_directory.json"
+        directory_file = _resolve_tota_home_fallback() / "channel_directory.json"
 
     if not directory_file.exists():
         return {}
@@ -373,11 +378,7 @@ class EventBridge:
             from hermes_constants import get_hermes_home
             db_file = get_hermes_home() / "state.db"
         except ImportError:
-            db_file = Path(
-                os.environ.get("TOTA_HOME")
-                or os.environ.get("HERMES_HOME")
-                or Path.home() / ".tota"
-            ) / "state.db"
+            db_file = _resolve_tota_home_fallback() / "state.db"
 
         try:
             db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0

--- a/tests/test_auto_mapper.py
+++ b/tests/test_auto_mapper.py
@@ -231,7 +231,8 @@ def test_ok_false_payload_does_not_mark_project_done(monkeypatch, fake_project):
     first = auto_mapper.maybe_map_project(fake_project)
     assert first["ran"] is True
     assert first["ok"] is False
-    assert "npx missing" in first["reason"]
+    reason = first["reason"]
+    assert isinstance(reason, str) and "npx missing" in reason
 
     second = auto_mapper.maybe_map_project(fake_project)
     assert second["ran"] is True  # retry allowed

--- a/tests/test_auto_mapper.py
+++ b/tests/test_auto_mapper.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import os
-import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -192,3 +190,48 @@ def test_propagates_subprocess_error(monkeypatch, fake_project):
     reason = status["reason"]
     assert isinstance(reason, str)
     assert "spawn-error" in reason
+
+
+def test_nonzero_exit_does_not_mark_project_done(monkeypatch, fake_project):
+    """Closes Copilot review: non-zero exit must allow retry within the same process."""
+    monkeypatch.delenv("TOTA_AUTO_MAP", raising=False)
+    monkeypatch.delenv("HERMES_AUTO_MAP", raising=False)
+    monkeypatch.setenv("TOTA_HOME", str(fake_project.parent / "tota"))
+
+    def _fail(cmd, **kwargs):
+        return SimpleNamespace(returncode=2, stdout="", stderr="boom")
+
+    monkeypatch.setattr(auto_mapper.subprocess, "run", _fail)
+
+    first = auto_mapper.maybe_map_project(fake_project)
+    assert first["ran"] is True
+    assert first["ok"] is False
+    assert first["returncode"] == 2
+
+    # A successful retry within the same process must spawn the mapper again.
+    second = auto_mapper.maybe_map_project(fake_project)
+    assert second["ran"] is True  # not deduped because the first failed
+
+
+def test_ok_false_payload_does_not_mark_project_done(monkeypatch, fake_project):
+    """Closes Copilot review: ok=false payload should not silently dedup."""
+    monkeypatch.delenv("TOTA_AUTO_MAP", raising=False)
+    monkeypatch.delenv("HERMES_AUTO_MAP", raising=False)
+    monkeypatch.setenv("TOTA_HOME", str(fake_project.parent / "tota"))
+
+    def _fake(cmd, **kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout='{"ok": false, "error": "npx missing"}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(auto_mapper.subprocess, "run", _fake)
+
+    first = auto_mapper.maybe_map_project(fake_project)
+    assert first["ran"] is True
+    assert first["ok"] is False
+    assert "npx missing" in first["reason"]
+
+    second = auto_mapper.maybe_map_project(fake_project)
+    assert second["ran"] is True  # retry allowed

--- a/tests/test_cli_startup_gating.py
+++ b/tests/test_cli_startup_gating.py
@@ -1,0 +1,76 @@
+"""Tests for the agent-side-effects subcommand gating in ``hermes_cli/main.py``.
+
+Closes Copilot review on PR #61: bootstrap + auto-mapper must NOT run for
+cheap utility subcommands (``hermes --help``, ``hermes config``, etc.).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_gating():
+    """Load the gating function out of ``hermes_cli/main.py`` without running its top-level side effects."""
+    src = (REPO_ROOT / "hermes_cli" / "main.py").read_text()
+    # The function and its constants are above any expensive imports.
+    namespace: dict = {"os": __import__("os"), "sys": __import__("sys")}
+    # Grab the function definition + the _AGENT_SUBCOMMANDS / _CHEAP_SUBCOMMANDS constants.
+    start = src.index("_AGENT_SUBCOMMANDS = frozenset")
+    end = src.index("if _should_run_agent_side_effects():")
+    exec(src[start:end], namespace)
+    return namespace["_should_run_agent_side_effects"]
+
+
+@pytest.fixture
+def gating(monkeypatch):
+    func = _load_gating()
+
+    def _set_argv(args):
+        monkeypatch.setattr(sys, "argv", ["hermes"] + list(args))
+        return func()
+
+    return _set_argv
+
+
+def test_bare_command_runs_hooks(gating):
+    assert gating([]) is True
+
+
+def test_help_skips_hooks(gating):
+    assert gating(["--help"]) is False
+    assert gating(["-h"]) is False
+    assert gating(["help"]) is False
+
+
+def test_version_skips_hooks(gating):
+    assert gating(["--version"]) is False
+    assert gating(["version"]) is False
+
+
+def test_cheap_utilities_skip_hooks(gating):
+    for cmd in ("config", "status", "doctor", "logout", "update", "tools", "skills"):
+        assert gating([cmd]) is False, f"Expected {cmd} to skip hooks"
+
+
+def test_agent_subcommands_run_hooks(gating):
+    for cmd in ("chat", "gateway", "cron", "acp", "kanban", "send"):
+        assert gating([cmd]) is True, f"Expected {cmd} to run hooks"
+
+
+def test_explicit_disable_overrides_subcommand(gating, monkeypatch):
+    monkeypatch.setenv("TOTA_SKIP_STARTUP_HOOKS", "1")
+    assert gating(["chat"]) is False
+    assert gating([]) is False
+
+
+def test_unknown_subcommand_defaults_to_run(gating):
+    # New / unrecognised subcommands default to running hooks rather than
+    # silently skipping them on a new addition.
+    assert gating(["whatever-new"]) is True

--- a/tests/test_tota_home_bootstrap.py
+++ b/tests/test_tota_home_bootstrap.py
@@ -71,7 +71,12 @@ def test_bootstrap_force_reseed_overwrites_existing(fresh_tota_home):
     tota_home_bootstrap.bootstrap_tota_home(force_reseed=True)
 
     assert target.read_text() != "operator override\n"
-    assert "0.14.0" in target.read_text()
+    # The repo's .tota/version is the source of truth — track whatever
+    # the current Tota version pin says, not a hardcoded value.
+    repo_version = (
+        (tota_home_bootstrap._repo_root() / ".tota" / "version").read_text().strip()
+    )
+    assert repo_version in target.read_text()
 
 
 def test_bootstrap_only_runs_once_per_process(fresh_tota_home):


### PR DESCRIPTION
## Summary

Closes Copilot's 6 post-merge review items on PR #61, and updates `docs/SPRINT_BACKLOG.md` to mark the 13 cherry-pick issues that were closed by the upstream Hermes v0.14.0 merge (`ab61ec254`).

| # | Item | Fix |
| --- | --- | --- |
| 1 | `agent/lsp/install.py` — env values not stripped | `.strip()` + `expanduser` on `TOTA_HOME` / `HERMES_HOME` |
| 2 | `gateway/shutdown_forensics.py` — same in signal-handler path | `.strip()` + `expanduser` |
| 3 | `mcp_serve.py` — three duplicate fallback sites | extracted `_resolve_tota_home_fallback()` once |
| 4 | `agent/auto_mapper.py` — `maybe_map_project` always dedups on success | gates dedup on `returncode == 0` AND `parsed["ok"]` |
| 5 | `tests/test_auto_mapper.py` — unused `os` / `subprocess` imports | removed |
| 6 | `hermes_cli/main.py` — bootstrap + auto-mapper at every CLI call | gated on subcommand; cheap utilities skip |

## Backlog sync

The upstream Hermes v0.14.0 merge (commit `ab61ec254`, landed by @wesleysimplicio) closed **13** cherry-pick issues at once:

- Sprint 1: #30, #31
- Sprint 2: #33, #34
- Sprint 3: #40, #42
- Sprint 4: #47, #48, #49, #50, #51, #52, #53, #54, #56, #57

Plus #55 (security trio) was landed directly via `9f16d52e4`, `8204a329c`, `0f3f23c19`.

**Remaining open** (all local-only work, not cherry-picks):

- #35 — `msgspec.Struct` migration (high-risk, dedicated PR)
- #36 — `run_agent.py` `orjson` migration (needs `strict=False` audit)
- #37 — `hermes_state.py` `orjson` migration (highest-risk, behind feature flag)
- #38 — Benchmark refresh (needs runtime benchmarking env)
- #45 — Native Windows beta (needs Windows runner)

## Tests

```
.venv/bin/python -m pytest \
    tests/test_auto_mapper.py \
    tests/test_tota_home_bootstrap.py \
    tests/test_map_project_skill.py \
    tests/test_tota_brand_pass.py \
    tests/test_cli_startup_gating.py \
    tests/test_hermes_constants.py \
    tests/test_hermes_home_profile_warning.py
======================== 101 passed, 1 skipped in 1.38s ========================
```

Two new auto_mapper regression cases (returncode-fail and ok-false-payload retry) + 8 new gating cases.

## Files touched

```
agent/auto_mapper.py                  (success-check + dedup gate)
agent/lsp/install.py                  (whitespace stripping)
docs/SPRINT_BACKLOG.md                (status sync after upstream merge)
gateway/shutdown_forensics.py         (whitespace stripping)
hermes_cli/main.py                    (subcommand gating)
mcp_serve.py                          (shared fallback resolver)
tests/test_auto_mapper.py             (drop unused imports + 2 new cases)
tests/test_cli_startup_gating.py      (new — 8 cases)
tests/test_tota_home_bootstrap.py     (version-pin-independent force-reseed assertion)
```

9 files, +274 / -64.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJdkokQD59pYAkKJCYfiqu)_