### PR TITLE
Fix Tota metadata after main merge

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.13.3",
+  "version": "0.14.2",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.13.3",
+      "package": "hermes-agent[acp]==0.14.2",
       "args": ["hermes-acp"]
     }
   }

--- a/acp_registry/icon.svg
+++ b/acp_registry/icon.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="none" role="img" aria-label="Tota Agent">
-  <circle cx="8" cy="8" r="7.2" fill="#C49A28"/>
-  <circle cx="8" cy="8" r="6.3" stroke="#3F4B2F" stroke-width="1.4"/>
-  <path d="M4.2 10.2 C5.1 6.9 6.5 4.6 9.2 3.9 C11.3 5.2 11.8 8 10.4 11.5 C8.6 10.3 6.4 10 4.2 10.2 Z" fill="#3F4B2F"/>
-  <path d="M5.2 5.9 C6.8 4.4 9.9 4.2 11.2 5.8 C9.7 5.7 8.8 6.1 8.4 7.1 C7.2 6.3 6.3 6 5.2 5.9 Z" fill="#1A2115"/>
-  <path d="M7.1 5.6 C8.1 4.8 9 4.8 10 5.4" stroke="#C49A28" stroke-width=".8" stroke-linecap="round"/>
+  <circle cx="8" cy="8" r="7.2" fill="currentColor"/>
+  <circle cx="8" cy="8" r="6.3" stroke="currentColor" stroke-width="1.4"/>
+  <path d="M4.2 10.2 C5.1 6.9 6.5 4.6 9.2 3.9 C11.3 5.2 11.8 8 10.4 11.5 C8.6 10.3 6.4 10 4.2 10.2 Z" fill="currentColor"/>
+  <path d="M5.2 5.9 C6.8 4.4 9.9 4.2 11.2 5.8 C9.7 5.7 8.8 6.1 8.4 7.1 C7.2 6.3 6.3 6 5.2 5.9 Z" fill="currentColor"/>
+  <path d="M7.1 5.6 C8.1 4.8 9 4.8 10 5.4" stroke="currentColor" stroke-width=".8" stroke-linecap="round"/>
 </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "hermes-agent"
 version = "0.14.2"
-description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
+description = "Tota Agent — a modified, faster Hermes that keeps the upstream core current"
 readme = "README.md"
 requires-python = ">=3.11"
 authors = [{ name = "Nous Research" }]
@@ -221,6 +221,9 @@ all = [
 hermes = "hermes_cli.main:main"
 hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
+tota = "hermes_cli.main:main"
+tota-agent = "run_agent:main"
+tota-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils"]

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -37,7 +37,7 @@ class TestSkinConfig:
     def test_get_branding_with_fallback(self):
         from hermes_cli.skin_engine import load_skin
         skin = load_skin("default")
-        assert skin.get_branding("agent_name") == "Hermes Agent"
+        assert skin.get_branding("agent_name") == "Tota Agent"
         assert skin.get_branding("nonexistent", "fallback") == "fallback"
 
     def test_get_spinner_wings_empty_for_default(self):
@@ -225,7 +225,7 @@ class TestUserSkins:
 
         assert skin.name == "broken"
         assert skin.get_color("banner_title") == "#FFD700"
-        assert skin.get_branding("agent_name") == "Hermes Agent"
+        assert skin.get_branding("agent_name") == "Tota Agent"
         assert skin.spinner.get("waiting_faces", []) == []
         assert skin.tool_emojis == {}
         assert skin.tool_prefix == "!"


### PR DESCRIPTION
## Summary
- restore Tota package metadata and console aliases after the Hermes 0.14.2 merge
- align ACP registry manifest version with pyproject
- make ACP icon registry-safe with currentColor only
- update skin tests for the fork default Tota identity

## Validation
- python -m pytest -o addopts='' tests/acp/test_registry_manifest.py tests/hermes_cli/test_skin_engine.py tests/test_tota_brand_pass.py -q --tb=short
- uv lock --check
- git diff --check --ignore-submodules
- taskflow run /tmp/tota-main-ci-fix