### PR TITLE
feat(perf): perf budgets CI + prompt-cache stable prefix

### DIFF
--- a/.github/workflows/perf-budgets.yml
+++ b/.github/workflows/perf-budgets.yml
@@ -1,0 +1,76 @@
+name: Perf budgets (non-blocking)
+
+# Issue #79: track regressions on key hot paths without blocking PRs.
+# Runs the small benchmark subset documented in scripts/perf_budgets.json,
+# uploads JSON + Markdown artifacts, and surfaces over-budget cases in the
+# step summary. Exit code is always 0 — this workflow is informational.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Nightly at 07:00 UTC — early enough for morning review, off-peak for runners.
+    - cron: "0 7 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: perf-budgets-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  benchmarks:
+    name: Run perf budget benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: |
+          uv venv .venv --python 3.11
+          source .venv/bin/activate
+          uv pip install -e ".[all,dev]"
+
+      - name: Run perf budgets
+        id: budgets
+        env:
+          # Benchmarks must not touch real APIs.
+          OPENROUTER_API_KEY: ""
+          OPENAI_API_KEY: ""
+          NOUS_API_KEY: ""
+        run: |
+          source .venv/bin/activate
+          # Non-blocking by design — script always exits 0.
+          python scripts/perf_budgets.py \
+            --samples 3 \
+            --output perf-budgets-report.json \
+            --summary perf-budgets-summary.md
+
+      - name: Append summary to step output
+        if: always()
+        run: |
+          if [ -f perf-budgets-summary.md ]; then
+            cat perf-budgets-summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload report artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-budgets-${{ github.run_id }}
+          path: |
+            perf-budgets-report.json
+            perf-budgets-summary.md
+          retention-days: 30
+          if-no-files-found: warn

--- a/docs/adr/0004-perf-budgets.md
+++ b/docs/adr/0004-perf-budgets.md
@@ -1,0 +1,101 @@
+# ADR-0004: Performance budgets and regression warnings in CI
+
+**Status:** Accepted.
+**Date:** 2026-05-19.
+**Owner:** @wesleysimplicio.
+**Related:** GitHub issue #79.
+
+## Context
+
+We already have two benchmark runners that exercise hot paths without making
+model API calls:
+
+* `scripts/benchmark_startup_perf.py` — import cost, tool-definition
+  assembly, plugin discovery, batch session writes.
+* `scripts/benchmark_runtime_usage.py` — runtime construction, parallel
+  guard, OpenRouter metadata cache, batched session append.
+
+Both are useful, but they're run manually. Nothing in CI catches a 2x
+slowdown landing in a PR; nothing produces a machine-readable artifact
+that we can diff against last week.
+
+Issue #79 asks for a small, stable benchmark subset wired into CI as
+**non-blocking** regression warnings.  Goal: catch obvious regressions
+fast, without making people fight flaky perf gates.
+
+## Decision
+
+We add:
+
+1. `scripts/perf_budgets.json` — the budgets file.  One entry per tracked
+   case with: `source` (benchmark script), `metric`, `budget` (seconds,
+   median), and a one-line `description`.
+2. `scripts/perf_budgets.py` — runner script.  Invokes the relevant
+   benchmark in `--json` mode, parses the median for each tracked case,
+   compares against the budget, and writes:
+   - `perf-budgets-report.json` (machine-readable)
+   - `perf-budgets-summary.md`  (human-readable table)
+   Exit code is **always 0**.  This script is informational — never
+   blocking.
+3. `.github/workflows/perf-budgets.yml` — workflow with two triggers:
+   - `workflow_dispatch` (manual)
+   - `schedule` nightly at 07:00 UTC
+   It runs the script, uploads both artifacts (30-day retention), and
+   appends the markdown summary to the GitHub step summary.
+
+### Tracked cases (initial set)
+
+| case | runner | budget (s, median) |
+| --- | --- | ---: |
+| `import_model_tools` | `benchmark_startup_perf.py` | 2.5 |
+| `get_tool_definitions` | `benchmark_startup_perf.py` | 1.5 |
+| `session_append_messages_batch` | `benchmark_startup_perf.py` | 0.5 |
+| `parallel_guard_read_files` | `benchmark_runtime_usage.py` | 0.5 |
+| `openrouter_metadata_disk_cache` | `benchmark_runtime_usage.py` | 1.5 |
+
+Budgets are intentionally generous — they're alarms for clear regressions,
+not optimisation targets.  A ratio of `< 1.0x` is "ok"; a ratio of
+`>= 1.0x` is flagged as `over_budget`.
+
+### Hardware assumption
+
+Budgets are calibrated for the default `ubuntu-latest` GitHub Actions
+runner (2 vCPU, 7 GB RAM).  Local runs may produce different absolute
+numbers — that's fine.  The script writes the medians it observed so a
+maintainer can compare apples to apples.
+
+## How to update budgets
+
+1. Run the script locally on a clean checkout of the branch you want to
+   anchor to:
+
+   ```bash
+   python scripts/perf_budgets.py --samples 5 --output /tmp/local.json
+   ```
+
+2. If a budget needs to change (true perf improvement, or a deliberate
+   trade-off), edit `scripts/perf_budgets.json` and:
+   - Keep the budget at least **1.5x** the median you actually observed,
+     so that runner jitter doesn't flap the warning every other night.
+   - Add a one-line note in the commit message saying *why* the budget
+     changed (improvement, refactor accepted slowdown, etc.).
+3. If a new hot path needs to be tracked, add a case to
+   `perf_budgets.json` and make sure the corresponding benchmark runner
+   knows the case name.
+
+## Consequences
+
+* CI nightly cost grows by ~one job run per day, ~5–10 minutes.
+* PRs are not gated.  A regression that lands during the day shows up
+  the next morning in the nightly report; we accept that latency in
+  exchange for zero false-positive blocking.
+* The JSON artifact format is `schema_version: 1`.  If we change it,
+  bump and document the change in this ADR.
+
+## Non-goals
+
+* This is **not** a benchmark suite for marketing claims — see the
+  existing `generate_tota_benchmark_report.py` for that.
+* This is **not** a performance gate.  Blocking gates need stable,
+  reproducible numbers (dedicated runners, controlled noise).  We are
+  not paying for that.

--- a/docs/adr/0005-prompt-cache-stable-prefix.md
+++ b/docs/adr/0005-prompt-cache-stable-prefix.md
@@ -1,0 +1,125 @@
+# ADR-0005: Prompt-cache stable prefix policy
+
+**Status:** Accepted (codifies existing contract in `_build_system_prompt_parts`).
+**Date:** 2026-05-19.
+**Owner:** @wesleysimplicio.
+**Related:** GitHub issue #80.
+
+## Context
+
+Modern provider APIs (Anthropic, OpenAI, OpenRouter, Cerebras, etc.)
+charge less and respond faster when the **prefix bytes** of a prompt
+match a previously-seen prefix.  Any divergence — even a single
+character — invalidates the cache from that point onward.
+
+If Hermes drops a timestamp, a session id, or a per-turn status string
+into the **middle** of the system prompt, every subsequent token after
+that string pays full price.  At Hermes' system-prompt size (tens of
+thousands of tokens for skill-rich setups), this is a real money +
+latency hit.
+
+`run_agent.py::AIAgent._build_system_prompt_parts` already implements
+the right shape: it returns three ordered tiers `stable` / `context` /
+`volatile` and the caller joins them in that order.  This ADR makes the
+contract explicit and adds a test guarding the stable prefix.
+
+## Decision
+
+The system prompt is assembled from three ordered tiers, joined with
+`"\n\n"`:
+
+### 1. `stable` (top — must be byte-identical across turns and across
+   sessions when inputs match)
+
+Allowed content:
+- SOUL.md identity (or fallback `DEFAULT_AGENT_IDENTITY`).
+- `HERMES_AGENT_HELP_GUIDANCE`.
+- Tool-aware behavioural guidance keyed on `valid_tool_names`
+  (memory, session_search, skills, kanban, computer_use, nous, etc.).
+- Tool-use enforcement guidance + model-family operational guidance
+  (Google, OpenAI, etc.) keyed on the *fixed* model string.
+- Skills system prompt (skills metadata is stable per agent
+  construction).
+- Environment hints (WSL / Termux / etc.) — fixed per process.
+- Platform hints — fixed per agent.
+
+Forbidden content:
+- Timestamps.
+- Session ids.
+- Per-turn runtime status (current cwd if it can change, current
+  branch, last tool result, etc.).
+- Anything that depends on `time.time()` or the live filesystem state
+  past startup.
+
+### 2. `context` (middle — stable per session, may vary between
+   sessions)
+
+Allowed content:
+- Caller-supplied `system_message`.
+- Context files discovered at cwd (`AGENTS.md`, `.cursorrules`,
+  `CLAUDE.md`, etc.).
+
+Notes:
+- Context can legitimately change between two `hermes` invocations
+  (different cwd, different `AGENTS.md`).  Within a single session,
+  it must not change — that would invalidate the cache mid-session.
+
+### 3. `volatile` (bottom — changes per turn, never expected to cache)
+
+Required to live here:
+- Memory snapshot blocks.
+- USER.md profile block.
+- External memory provider blocks.
+- Timestamp line (`Conversation started: ...`).
+- Session ID line.
+- Live model / provider identity (mutable in some failover scenarios).
+
+The volatile tier is at the **end** of the system prompt on purpose:
+a divergence here only loses the last few hundred tokens of cache, not
+the entire 30k-token prefix above it.
+
+## Caching guarantees
+
+* Two `AIAgent` instances constructed with the same model, provider,
+  `valid_tool_names`, platform, and identity files must produce the
+  same `stable` string.  Bytes-equal.  No exceptions.
+* The full system prompt is cached on the agent instance
+  (`_cached_system_prompt`) and never re-rendered mid-session, even
+  when memory or user-profile content changes — that change applies
+  the next turn through the standard message channel, not by editing
+  the system prompt.
+
+## How to extend safely
+
+* New tool guidance → goes in the `stable` tier, gated on a fixed
+  `valid_tool_names` check.
+* New per-call status → goes in the `volatile` tier, **or** is
+  attached as a user-message preamble for the turn.  Never inject into
+  `stable` or `context`.
+* New context source → goes in the `context` tier, must be deterministic
+  given the cwd inputs.
+
+## Test
+
+`tests/test_prompt_cache_stability.py` exercises
+`_build_system_prompt_parts` twice with the same stable inputs and
+asserts the `stable` tier is byte-identical.  It also asserts the
+`volatile` tier is permitted to differ across runs (sanity-check that
+we're testing the right thing).
+
+## Consequences
+
+* New contributors get a documented rule instead of "ask Wesley".
+* The test fails loudly the first time someone shoves a timestamp into
+  `stable_parts`.
+* The contract is enforced by code structure (three explicit tiers),
+  not by review discipline alone.
+
+## Non-goals
+
+* This ADR does **not** add provider-side cache control directives
+  (`cache_control: ephemeral`, OpenRouter `cache_breakpoints`, etc.).
+  Those are tracked separately and orthogonal to prefix stability.
+* This ADR does **not** redefine the message-list portion of the
+  prompt (user / assistant / tool messages).  Cache control there is
+  handled by the existing provider adapters.

--- a/scripts/perf_budgets.json
+++ b/scripts/perf_budgets.json
@@ -1,0 +1,43 @@
+{
+  "_comment": "Performance budgets for Hermes hot paths. See docs/adr/0004-perf-budgets.md for policy and update procedure. Budgets are intentionally generous regression alarms — they are NOT performance targets. Warnings only; CI is non-blocking.",
+  "_schema_version": 1,
+  "_unit": "seconds (median across N samples)",
+  "_methodology": {
+    "runner": "scripts/benchmark_startup_perf.py and scripts/benchmark_runtime_usage.py",
+    "default_samples": 3,
+    "isolation": "fresh subprocess per sample",
+    "hardware_note": "Budgets are calibrated for ubuntu-latest GitHub Actions runners (2 vCPU, 7GB RAM). Local runs may differ — see ADR-0004."
+  },
+  "cases": {
+    "import_model_tools": {
+      "source": "benchmark_startup_perf.py",
+      "metric": "elapsed_median_seconds",
+      "budget": 2.5,
+      "description": "Time to import the model_tools module from cold (proxy for cold-start tool registry load)."
+    },
+    "get_tool_definitions": {
+      "source": "benchmark_startup_perf.py",
+      "metric": "elapsed_median_seconds",
+      "budget": 1.5,
+      "description": "Cold call to model_tools.get_tool_definitions() after import. Measures schema assembly cost."
+    },
+    "session_append_messages_batch": {
+      "source": "benchmark_startup_perf.py",
+      "metric": "elapsed_median_seconds",
+      "budget": 0.5,
+      "description": "SessionDB.append_messages() batch insert for ~180 messages. Lower is better — protects the batched persistence path."
+    },
+    "parallel_guard_read_files": {
+      "source": "benchmark_runtime_usage.py",
+      "metric": "elapsed_median_seconds",
+      "budget": 0.5,
+      "description": "_should_parallelize_tool_batch() hot-loop guard (10k iterations of an 8-tool batch). Catches regressions in the parallel-tool gating fast path."
+    },
+    "openrouter_metadata_disk_cache": {
+      "source": "benchmark_runtime_usage.py",
+      "metric": "elapsed_median_seconds",
+      "budget": 1.5,
+      "description": "Disk-cache-backed fetch_model_metadata() for 500 models, 100 iterations. Guards the OpenRouter metadata cache fast path against network/parse regressions."
+    }
+  }
+}

--- a/scripts/perf_budgets.py
+++ b/scripts/perf_budgets.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Run a small stable benchmark subset and compare results against perf budgets.
+
+Issue #79: non-blocking CI regression warnings.
+
+The budgets file lives at ``scripts/perf_budgets.json`` and documents which
+cases we track, the unit (seconds, median across samples), and generous
+warning thresholds.  Exit code is **always 0**: this script is informational
+only, it never blocks CI.  Warnings are emitted to stdout and a structured
+JSON artifact is written for downstream upload.
+
+Usage
+-----
+
+    python scripts/perf_budgets.py \\
+        --samples 3 \\
+        --output perf-budgets-report.json \\
+        --summary perf-budgets-summary.md
+
+Outputs
+-------
+
+* ``--output`` (JSON) — machine-readable report: per-case median + budget +
+  status (``ok`` / ``over_budget`` / ``error``).
+* ``--summary`` (Markdown) — short human summary; same data, table form.
+
+How budgets map to runners
+--------------------------
+
+* ``import_model_tools``, ``get_tool_definitions``, ``session_append_messages_batch``
+  are produced by ``scripts/benchmark_startup_perf.py``.
+* ``parallel_guard_read_files``, ``openrouter_metadata_disk_cache`` are
+  produced by ``scripts/benchmark_runtime_usage.py``.
+
+The benchmark runners emit ``--json`` keyed by case name with a ``median``
+field per case.  We honour that contract; if a case is missing we mark it
+``error`` and continue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BUDGETS_FILE = Path(__file__).resolve().parent / "perf_budgets.json"
+
+
+# Which runner script produces which cases.
+_STARTUP_CASES = {
+    "import_model_tools",
+    "get_tool_definitions",
+    "session_append_messages_batch",
+}
+_RUNTIME_CASES = {
+    "parallel_guard_read_files",
+    "openrouter_metadata_disk_cache",
+}
+
+
+def _load_budgets() -> dict:
+    with BUDGETS_FILE.open("r", encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+def _run_benchmark(script: str, cases: list[str], samples: int) -> dict:
+    """Invoke a benchmark runner in ``--json`` mode for the given cases."""
+    cmd = [sys.executable, str(REPO_ROOT / "scripts" / script), "--json", "-n", str(samples)]
+    for case in cases:
+        cmd += ["--case", case]
+    proc = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return {
+            "_ok": False,
+            "_stderr": proc.stderr.strip()[-4000:],
+            "_stdout": proc.stdout.strip()[-2000:],
+        }
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return {"_ok": False, "_error": str(exc), "_stdout": proc.stdout.strip()[-2000:]}
+
+
+def _evaluate(case: str, budget: float, runner_output: dict) -> dict:
+    """Compare a runner result against the budget. Status: ok / over_budget / error."""
+    entry = runner_output.get(case) if isinstance(runner_output, dict) else None
+    if not entry or not entry.get("ok"):
+        return {
+            "case": case,
+            "status": "error",
+            "budget_seconds": budget,
+            "median_seconds": None,
+            "reason": "benchmark did not produce a result",
+        }
+    median = entry.get("median")
+    if median is None:
+        return {
+            "case": case,
+            "status": "error",
+            "budget_seconds": budget,
+            "median_seconds": None,
+            "reason": "benchmark output missing median field",
+        }
+    over = median > budget
+    return {
+        "case": case,
+        "status": "over_budget" if over else "ok",
+        "budget_seconds": budget,
+        "median_seconds": median,
+        "ratio": (median / budget) if budget else None,
+    }
+
+
+def _write_summary(report: dict, path: Path) -> None:
+    lines: list[str] = []
+    lines.append("# Hermes performance budgets — regression report")
+    lines.append("")
+    lines.append(f"Samples per case: {report['samples']}")
+    lines.append("")
+    lines.append("| case | median (s) | budget (s) | ratio | status |")
+    lines.append("| --- | ---: | ---: | ---: | --- |")
+    for row in report["cases"]:
+        median = row.get("median_seconds")
+        ratio = row.get("ratio")
+        median_str = f"{median:.4f}" if isinstance(median, (int, float)) else "n/a"
+        ratio_str = f"{ratio:.2f}x" if isinstance(ratio, (int, float)) else "n/a"
+        lines.append(
+            f"| {row['case']} | {median_str} | {row['budget_seconds']:.4f} | "
+            f"{ratio_str} | {row['status']} |"
+        )
+    if report["warnings"]:
+        lines.append("")
+        lines.append("## Warnings")
+        for w in report["warnings"]:
+            lines.append(f"- {w}")
+    lines.append("")
+    lines.append("> Budgets are non-blocking regression alarms, not targets.")
+    lines.append("> See `docs/adr/0004-perf-budgets.md` to update.")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-n", "--samples", type=int, default=3)
+    parser.add_argument("--output", type=Path, default=Path("perf-budgets-report.json"))
+    parser.add_argument("--summary", type=Path, default=Path("perf-budgets-summary.md"))
+    parser.add_argument(
+        "--skip-runtime",
+        action="store_true",
+        help="Skip the runtime benchmark runner (useful when only startup paths changed).",
+    )
+    parser.add_argument(
+        "--skip-startup",
+        action="store_true",
+        help="Skip the startup benchmark runner.",
+    )
+    args = parser.parse_args()
+
+    budgets = _load_budgets()
+    case_budgets: dict[str, float] = {
+        name: float(meta["budget"]) for name, meta in budgets["cases"].items()
+    }
+
+    startup_cases = [c for c in _STARTUP_CASES if c in case_budgets]
+    runtime_cases = [c for c in _RUNTIME_CASES if c in case_budgets]
+
+    runner_output: dict = {}
+    if startup_cases and not args.skip_startup:
+        out = _run_benchmark("benchmark_startup_perf.py", startup_cases, args.samples)
+        runner_output.update(out if isinstance(out, dict) else {})
+    if runtime_cases and not args.skip_runtime:
+        out = _run_benchmark("benchmark_runtime_usage.py", runtime_cases, args.samples)
+        runner_output.update(out if isinstance(out, dict) else {})
+
+    rows = [_evaluate(case, budget, runner_output) for case, budget in case_budgets.items()]
+    warnings: list[str] = []
+    for row in rows:
+        if row["status"] == "over_budget":
+            warnings.append(
+                f"{row['case']}: median {row['median_seconds']:.4f}s > "
+                f"budget {row['budget_seconds']:.4f}s "
+                f"({row['ratio']:.2f}x)"
+            )
+        elif row["status"] == "error":
+            warnings.append(f"{row['case']}: {row.get('reason', 'unknown error')}")
+
+    report = {
+        "schema_version": budgets.get("_schema_version", 1),
+        "samples": args.samples,
+        "cases": rows,
+        "warnings": warnings,
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+
+    args.summary.parent.mkdir(parents=True, exist_ok=True)
+    _write_summary(report, args.summary)
+
+    # Emit a compact line for CI logs.
+    print(json.dumps({"warnings": warnings, "cases": len(rows)}))
+    # Always exit 0 — non-blocking by design (see ADR-0004).
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_prompt_cache_stability.py
+++ b/tests/test_prompt_cache_stability.py
@@ -1,0 +1,113 @@
+"""Guard the prompt-cache stable prefix policy (ADR-0005).
+
+Issue #80.  The system prompt is assembled from three tiers
+(`stable` / `context` / `volatile`) by
+``AIAgent._build_system_prompt_parts``.  The `stable` tier must be
+byte-identical across two agents constructed with the same stable
+inputs — otherwise upstream provider prefix caches (Anthropic,
+OpenAI, OpenRouter, Cerebras, ...) miss on every turn and we pay full
+token price for tens of thousands of tokens of system prompt.
+
+If this test fails, someone added a non-deterministic value
+(timestamp, session id, runtime status, etc.) into the `stable` tier.
+Move it to `volatile_parts` instead — see ADR-0005.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_tool_defs(*names: str) -> list:
+    """Minimal tool definition list accepted by AIAgent.__init__."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _build_agent():
+    """Construct an AIAgent with the OpenAI client + tool loading mocked.
+
+    Mirrors the fixture pattern from tests/run_agent/test_run_agent.py.
+    """
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+    return agent
+
+
+def test_stable_prefix_is_byte_identical_across_constructions():
+    """Two agents with identical stable inputs must produce identical `stable`.
+
+    This is the core ADR-0005 contract.  If this fails, the system
+    prompt has acquired a non-deterministic value (timestamp, uuid,
+    live-fs read, etc.) in the stable tier.
+    """
+    agent_a = _build_agent()
+    agent_b = _build_agent()
+
+    parts_a = agent_a._build_system_prompt_parts()
+    parts_b = agent_b._build_system_prompt_parts()
+
+    assert parts_a["stable"] == parts_b["stable"], (
+        "Stable prefix diverged between two equivalent agent constructions. "
+        "Something non-deterministic snuck into `stable_parts` — move it to "
+        "`volatile_parts` (see docs/adr/0005-prompt-cache-stable-prefix.md)."
+    )
+
+
+def test_volatile_tier_contains_timestamp():
+    """Sanity check: timestamps live in `volatile`, not `stable`.
+
+    Confirms the test above is testing the right thing — if the
+    timestamp ever moves up into `stable`, this assertion will keep
+    pointing at the right tier and the byte-identity test will start
+    failing.
+    """
+    agent = _build_agent()
+    parts = agent._build_system_prompt_parts()
+    assert "Conversation started:" in parts["volatile"], (
+        "Expected the timestamp line in the volatile tier. "
+        "If you moved it, update ADR-0005 and this test together."
+    )
+    assert "Conversation started:" not in parts["stable"], (
+        "Timestamp leaked into the stable tier. This invalidates the "
+        "prompt-cache prefix on every turn. See ADR-0005."
+    )
+
+
+def test_stable_prefix_does_not_contain_session_id():
+    """Session ids belong in `volatile`, never in `stable`."""
+    agent = _build_agent()
+    agent.session_id = "session-deterministic-id-for-test"
+    agent.pass_session_id = True
+    parts = agent._build_system_prompt_parts()
+    assert agent.session_id not in parts["stable"], (
+        "Session id leaked into the stable prefix. Move it to volatile_parts."
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #79
Closes #80

## Summary

Two non-blocking perf-hygiene additions:

### #79 — Performance budgets CI
- `scripts/perf_budgets.json` — budget config for 5 tracked hot paths (`import_model_tools`, `get_tool_definitions`, `session_append_messages_batch`, `parallel_guard_read_files`, `openrouter_metadata_disk_cache`). Budgets are generous regression alarms, not targets.
- `scripts/perf_budgets.py` — runs the existing `benchmark_startup_perf.py` / `benchmark_runtime_usage.py` in `--json` mode, compares medians against budgets, writes machine-readable JSON + human Markdown summary. Always exits 0 (non-blocking).
- `.github/workflows/perf-budgets.yml` — `workflow_dispatch` + nightly 07:00 UTC cron. Uploads both artifacts (30-day retention) and appends summary to step summary.
- `docs/adr/0004-perf-budgets.md` — policy + how to update budgets safely (1.5x observed median rule, etc.).

### #80 — Prompt-cache stable prefix policy
- `docs/adr/0005-prompt-cache-stable-prefix.md` — codifies the `stable` / `context` / `volatile` tier contract already implemented by `AIAgent._build_system_prompt_parts` (`run_agent.py:6028+`). Lists allowed/forbidden content per tier, plus extension rules.
- `tests/test_prompt_cache_stability.py` — asserts the stable tier is byte-identical across two equivalent agent constructions, and that timestamps + session ids live in the volatile tier.

No production code changes. Existing tier separation in `_build_system_prompt_parts` was already correct; this PR adds the contract document + a regression test so it stays that way.

## Test plan
- [ ] Manually trigger `Perf budgets (non-blocking)` workflow via `workflow_dispatch` and verify artifacts upload.
- [ ] Run `pytest tests/test_prompt_cache_stability.py -v` locally and confirm 3 tests pass.
- [ ] Confirm nightly cron fires once (next 07:00 UTC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)