### PR TITLE
track(#81): Add warm daemon mode for desktop and car profiles

### DIFF
--- a/.plans/issue-81-add-warm-daemon-mode-for-desktop-and-car-profiles.md
+++ b/.plans/issue-81-add-warm-daemon-mode-for-desktop-and-car-profiles.md
@@ -1,0 +1,35 @@
+# Issue #81: Add warm daemon mode for desktop and car profiles
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/81
+
+## Original description (excerpt)
+
+```
+## Goal
+Make Hermes Turbo Agent feel instant in desktop and car variants by keeping expensive runtime state warm.
+
+## Context
+The new `desktop` and `car` distributions should not pay full startup/discovery cost for every interaction. A local daemon can keep registry, skill index, provider metadata, MCP fingerprints, and session DB state warm.
+
+## Acceptance criteria
+- Define a daemon architecture for desktop and car profile use.
+- Preload safe caches: tool registry, skill index, provider metadata, MCP/config fingerprints, and recent session summaries.
+- Add health/status commands for the daemon.
+- Add safe invalidation when config, plugin, skills, or tool files change.
+- Document fallbacks when daemon is not running.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/docker/systemd/hermes-daemon-car.service
+++ b/docker/systemd/hermes-daemon-car.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Hermes warm daemon (car profile)
+Documentation=https://github.com/wesleysimplicio/hermes-turbo-agent/blob/main/docs/runtime/warm-daemon.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/env python -m hermes_cli.daemon start --profile car
+ExecStop=/usr/bin/env python -m hermes_cli.daemon stop
+Restart=on-failure
+RestartSec=2
+Environment=PYTHONUNBUFFERED=1
+# Car profile runs on constrained hardware — tighter quotas
+CPUQuota=40%
+MemoryMax=512M
+TasksMax=64
+
+[Install]
+WantedBy=default.target

--- a/docker/systemd/hermes-daemon-desktop.service
+++ b/docker/systemd/hermes-daemon-desktop.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Hermes warm daemon (desktop profile)
+Documentation=https://github.com/wesleysimplicio/hermes-turbo-agent/blob/main/docs/runtime/warm-daemon.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/env python -m hermes_cli.daemon start --profile desktop
+ExecStop=/usr/bin/env python -m hermes_cli.daemon stop
+Restart=on-failure
+RestartSec=3
+Environment=PYTHONUNBUFFERED=1
+# Resource guardrails (see AGENTS.md yool/tuple/HAMT §11)
+CPUQuota=60%
+MemoryMax=1G
+TasksMax=128
+
+[Install]
+WantedBy=default.target

--- a/docs/runtime/warm-daemon.md
+++ b/docs/runtime/warm-daemon.md
@@ -1,0 +1,89 @@
+# Warm Daemon
+
+The warm daemon keeps expensive runtime state hot for the `desktop` and `car`
+Hermes profiles. Without it, every interaction pays the full cold-start cost:
+tool registry scan, skill index build, provider metadata fetch, MCP/config
+fingerprinting and session summary load.
+
+## Quick start
+
+```bash
+# foreground (dev)
+python -m hermes_cli.daemon start --profile desktop
+
+# inspect
+python -m hermes_cli.daemon status
+
+# stop
+python -m hermes_cli.daemon stop
+```
+
+The default socket lives at `~/.hermes/daemon.sock` with `0600` perms. Override
+with `--socket /path/to/sock`.
+
+## Profiles
+
+| Profile | Preloads |
+|---------|----------|
+| `desktop` | tool_registry, skill_index, provider_metadata, mcp_fingerprints, session_summaries |
+| `car` | tool_registry, skill_index, provider_metadata |
+
+`car` is intentionally lean — the hardware budget is tight and conversational
+latency matters more than recall.
+
+## systemd
+
+Drop the unit files in `docker/systemd/` into `~/.config/systemd/user/` (user
+service) or `/etc/systemd/system/` (system service):
+
+```bash
+cp docker/systemd/hermes-daemon-desktop.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now hermes-daemon-desktop.service
+```
+
+For the car profile swap `desktop` → `car`. Both units ship CPU/memory
+guardrails (see AGENTS.md yool/tuple/HAMT §11) so a runaway preload cannot
+fry the host.
+
+## Invalidation
+
+Config, plugin, skill or tool changes can stale a cache. Force a refresh:
+
+```bash
+python -m hermes_cli.daemon invalidate skill_index
+python -m hermes_cli.daemon invalidate tool_registry
+```
+
+A file-watcher hook is planned (`watchdog` on `skills/`, `plugins/`, `tools/`
+and the active config) but lives outside this initial scaffold.
+
+## Fallback when daemon is offline
+
+Every client call goes through `_client_request`. If the socket is missing or
+unresponsive, the response is:
+
+```json
+{"ok": false, "error": "...", "fallback": "cold"}
+```
+
+Callers MUST treat `fallback: cold` as a signal to re-run the regular cold
+path. The daemon is an optimization — never a hard dependency. UX never blocks
+on it.
+
+## Protocol
+
+UNIX socket, line-oriented JSON. Operations:
+
+| op | payload | response |
+|----|---------|----------|
+| `status` | — | `{ok, profile, uptime_s, caches[]}` |
+| `ping` | — | `{ok, pong}` |
+| `invalidate` | `{cache: "..."}` | `{ok, invalidated}` |
+| `shutdown` | — | `{ok, bye}` |
+
+## Security
+
+- Socket perms: `0600` (owner only).
+- Daemon never executes arbitrary code from requests.
+- No network listener. Local UNIX socket only.

--- a/hermes_cli/daemon.py
+++ b/hermes_cli/daemon.py
@@ -1,0 +1,231 @@
+"""
+Hermes warm daemon — keeps expensive runtime state hot for desktop/car profiles.
+
+Goal: avoid paying full startup/discovery cost on every interaction. The daemon
+preloads tool registry, skill index, provider metadata, MCP/config fingerprints
+and recent session summaries, then exposes a tiny request loop over a UNIX
+socket. CLI clients connect, send a JSON request, get a JSON response.
+
+This is a minimal, dependency-free scaffold. Heavy preloads are wired as
+lazy callables so the file imports cleanly without the full runtime.
+
+Subcommands:
+    hermes daemon start [--profile desktop|car] [--socket PATH]
+    hermes daemon stop  [--socket PATH]
+    hermes daemon status [--socket PATH]
+
+Fallback: when the daemon socket is missing or unresponsive, callers MUST
+re-execute the cold path. Never block UX on a warm daemon.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+PROFILES = ("desktop", "car")
+DEFAULT_SOCKET = Path.home() / ".hermes" / "daemon.sock"
+DEFAULT_PIDFILE = Path.home() / ".hermes" / "daemon.pid"
+
+
+def _socket_path(arg: str | None) -> Path:
+    return Path(arg) if arg else DEFAULT_SOCKET
+
+
+def _pid_path(sock: Path) -> Path:
+    return sock.with_suffix(".pid")
+
+
+def _ensure_dir(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Warm caches (lazy)
+# ---------------------------------------------------------------------------
+
+
+def _preload_tool_registry() -> dict[str, Any]:
+    try:
+        import toolsets  # noqa: F401
+        return {"ok": True, "module": "toolsets"}
+    except Exception as exc:  # pragma: no cover - environment-dependent
+        return {"ok": False, "error": repr(exc)}
+
+
+def _preload_skill_index() -> dict[str, Any]:
+    skills_dir = Path(__file__).resolve().parent.parent / "skills"
+    if not skills_dir.exists():
+        return {"ok": False, "error": "skills/ missing"}
+    return {"ok": True, "count": sum(1 for _ in skills_dir.glob("*"))}
+
+
+def _preload_provider_metadata() -> dict[str, Any]:
+    return {"ok": True, "providers": ["deepseek", "openai", "anthropic"]}
+
+
+def _preload_mcp_fingerprints() -> dict[str, Any]:
+    return {"ok": True, "fingerprints": {}}
+
+
+def _preload_session_summaries() -> dict[str, Any]:
+    return {"ok": True, "summaries": []}
+
+
+PRELOADERS: dict[str, Callable[[], dict[str, Any]]] = {
+    "tool_registry": _preload_tool_registry,
+    "skill_index": _preload_skill_index,
+    "provider_metadata": _preload_provider_metadata,
+    "mcp_fingerprints": _preload_mcp_fingerprints,
+    "session_summaries": _preload_session_summaries,
+}
+
+
+PROFILE_PRELOADS: dict[str, tuple[str, ...]] = {
+    "desktop": tuple(PRELOADERS),
+    "car": ("tool_registry", "skill_index", "provider_metadata"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
+
+
+def _serve(sock_path: Path, profile: str) -> int:
+    if profile not in PROFILES:
+        print(f"unknown profile: {profile}", file=sys.stderr)
+        return 2
+
+    _ensure_dir(sock_path)
+    if sock_path.exists():
+        sock_path.unlink()
+
+    pid_path = _pid_path(sock_path)
+    pid_path.write_text(str(os.getpid()))
+
+    caches: dict[str, dict[str, Any]] = {}
+    for name in PROFILE_PRELOADS[profile]:
+        caches[name] = PRELOADERS[name]()
+
+    started = time.time()
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(str(sock_path))
+    srv.listen(8)
+    os.chmod(sock_path, 0o600)
+
+    print(f"hermes daemon ready profile={profile} socket={sock_path}", flush=True)
+
+    try:
+        while True:
+            conn, _ = srv.accept()
+            with conn:
+                try:
+                    raw = conn.recv(8192).decode("utf-8", errors="replace")
+                    req = json.loads(raw or "{}")
+                except json.JSONDecodeError as exc:
+                    conn.sendall(json.dumps({"ok": False, "error": str(exc)}).encode())
+                    continue
+
+                op = req.get("op", "status")
+                if op == "status":
+                    resp = {
+                        "ok": True,
+                        "profile": profile,
+                        "uptime_s": round(time.time() - started, 2),
+                        "caches": list(caches),
+                    }
+                elif op == "ping":
+                    resp = {"ok": True, "pong": True}
+                elif op == "invalidate":
+                    target = req.get("cache")
+                    if target in PRELOADERS:
+                        caches[target] = PRELOADERS[target]()
+                        resp = {"ok": True, "invalidated": target}
+                    else:
+                        resp = {"ok": False, "error": f"unknown cache: {target}"}
+                elif op == "shutdown":
+                    conn.sendall(json.dumps({"ok": True, "bye": True}).encode())
+                    break
+                else:
+                    resp = {"ok": False, "error": f"unknown op: {op}"}
+
+                conn.sendall(json.dumps(resp).encode())
+    finally:
+        srv.close()
+        if sock_path.exists():
+            sock_path.unlink()
+        if pid_path.exists():
+            pid_path.unlink()
+    return 0
+
+
+def _client_request(sock_path: Path, payload: dict[str, Any], timeout: float = 2.0) -> dict[str, Any]:
+    if not sock_path.exists():
+        return {"ok": False, "error": "daemon not running", "fallback": "cold"}
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as c:
+            c.settimeout(timeout)
+            c.connect(str(sock_path))
+            c.sendall(json.dumps(payload).encode())
+            data = c.recv(65536)
+            return json.loads(data.decode("utf-8", errors="replace") or "{}")
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"ok": False, "error": repr(exc), "fallback": "cold"}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="hermes-daemon", description="Hermes warm daemon")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("start", help="Start the warm daemon (foreground)")
+    s.add_argument("--profile", choices=PROFILES, default="desktop")
+    s.add_argument("--socket", default=None)
+
+    st = sub.add_parser("stop", help="Stop the warm daemon")
+    st.add_argument("--socket", default=None)
+
+    ss = sub.add_parser("status", help="Show daemon status")
+    ss.add_argument("--socket", default=None)
+
+    inv = sub.add_parser("invalidate", help="Invalidate a warm cache")
+    inv.add_argument("cache", choices=tuple(PRELOADERS))
+    inv.add_argument("--socket", default=None)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    sock = _socket_path(args.socket)
+
+    if args.cmd == "start":
+        return _serve(sock, args.profile)
+    if args.cmd == "stop":
+        resp = _client_request(sock, {"op": "shutdown"})
+        print(json.dumps(resp))
+        return 0 if resp.get("ok") else 1
+    if args.cmd == "status":
+        resp = _client_request(sock, {"op": "status"})
+        print(json.dumps(resp, indent=2))
+        return 0 if resp.get("ok") else 1
+    if args.cmd == "invalidate":
+        resp = _client_request(sock, {"op": "invalidate", "cache": args.cache})
+        print(json.dumps(resp))
+        return 0 if resp.get("ok") else 1
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Tracks #81 — previously closed without commits, reopened to deliver real implementation.

## Scope
Add warm daemon mode for desktop and car profiles

## Status
Scaffold only. Implementation plan in `.plans/issue-81-add-warm-daemon-mode-for-desktop-and-car-profiles.md`. Will be expanded in follow-up commits until DoD is green.

Refs #81