### PR TITLE
track(#82): Add runtime performance dashboard and stage telemetry

### DIFF
--- a/.plans/issue-82-add-runtime-performance-dashboard-and-stage-telemetry.md
+++ b/.plans/issue-82-add-runtime-performance-dashboard-and-stage-telemetry.md
@@ -1,0 +1,35 @@
+# Issue #82: Add runtime performance dashboard and stage telemetry
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/82
+
+## Original description (excerpt)
+
+```
+## Goal
+Expose where time is spent during real Hermes Turbo Agent runs.
+
+## Context
+To keep improving speed, the project needs visibility into context build, prompt build, model calls, tool dispatch, DB writes, MCP reloads, delegation, retries, and UI event bursts.
+
+## Acceptance criteria
+- Add structured timing events for major runtime stages.
+- Preserve privacy by avoiding prompt/secret capture in telemetry payloads.
+- Add a local dashboard or report view that shows stage timings per run.
+- Include provider/model/tool breakdowns when available.
+- Add docs explaining how to use telemetry to diagnose slow runs.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/agent/telemetry/__init__.py
+++ b/agent/telemetry/__init__.py
@@ -1,0 +1,9 @@
+"""Runtime performance telemetry for Hermes Turbo Agent.
+
+Exposes lightweight stage timing primitives and a CLI dashboard reader.
+No external dependencies; safe for production hot paths.
+"""
+
+from .stage_timer import StageTimer, record_stage, set_log_path, get_log_path
+
+__all__ = ["StageTimer", "record_stage", "set_log_path", "get_log_path"]

--- a/agent/telemetry/dashboard.py
+++ b/agent/telemetry/dashboard.py
@@ -1,0 +1,137 @@
+"""CLI dashboard: reads the telemetry JSONL and prints per-stage percentiles.
+
+Usage:
+    python -m agent.telemetry.dashboard [--log PATH] [--group-by stage|provider|model|tool]
+
+Outputs an ASCII table with count, p50, p95, p99, and mean (milliseconds) per
+group key. Pure stdlib; safe to run offline against a captured log.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+from .stage_timer import get_log_path
+
+
+GROUP_KEYS = ("stage", "provider", "model", "tool")
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float:
+    if not sorted_values:
+        return 0.0
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    # Nearest-rank percentile (no interpolation, stdlib only).
+    k = max(0, min(len(sorted_values) - 1, int(round(pct / 100.0 * (len(sorted_values) - 1)))))
+    return sorted_values[k]
+
+
+def _iter_events(path: Path) -> Iterable[dict]:
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def summarize(path: Path, group_by: str = "stage") -> list[dict]:
+    """Aggregate JSONL events into per-group percentile rows."""
+    if group_by not in GROUP_KEYS:
+        raise ValueError(f"group_by must be one of {GROUP_KEYS}, got {group_by!r}")
+    buckets: dict[str, list[float]] = defaultdict(list)
+    errors: dict[str, int] = defaultdict(int)
+    for event in _iter_events(path):
+        key = event.get(group_by) or "(none)"
+        try:
+            buckets[key].append(float(event.get("duration_ms", 0.0)))
+        except (TypeError, ValueError):
+            continue
+        if not event.get("ok", True):
+            errors[key] += 1
+    rows: list[dict] = []
+    for key, durations in buckets.items():
+        durations.sort()
+        count = len(durations)
+        rows.append(
+            {
+                "key": key,
+                "count": count,
+                "errors": errors.get(key, 0),
+                "p50_ms": round(_percentile(durations, 50), 2),
+                "p95_ms": round(_percentile(durations, 95), 2),
+                "p99_ms": round(_percentile(durations, 99), 2),
+                "mean_ms": round(sum(durations) / count, 2) if count else 0.0,
+            }
+        )
+    rows.sort(key=lambda r: r["p95_ms"], reverse=True)
+    return rows
+
+
+def format_table(rows: list[dict], group_by: str) -> str:
+    header = (group_by, "count", "errors", "p50_ms", "p95_ms", "p99_ms", "mean_ms")
+    widths = [max(len(h), 8) for h in header]
+    str_rows = []
+    for r in rows:
+        cells = (
+            str(r["key"]),
+            str(r["count"]),
+            str(r["errors"]),
+            f"{r['p50_ms']:.2f}",
+            f"{r['p95_ms']:.2f}",
+            f"{r['p99_ms']:.2f}",
+            f"{r['mean_ms']:.2f}",
+        )
+        str_rows.append(cells)
+        for i, c in enumerate(cells):
+            widths[i] = max(widths[i], len(c))
+    sep_line = "+".join("-" * (w + 2) for w in widths)
+    sep_line = f"+{sep_line}+"
+
+    def fmt(cells: tuple[str, ...]) -> str:
+        return "| " + " | ".join(c.ljust(w) for c, w in zip(cells, widths)) + " |"
+
+    lines = [sep_line, fmt(header), sep_line]
+    lines.extend(fmt(c) for c in str_rows)
+    lines.append(sep_line)
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Hermes runtime telemetry dashboard")
+    parser.add_argument("--log", type=Path, default=None, help="path to telemetry JSONL")
+    parser.add_argument(
+        "--group-by",
+        choices=GROUP_KEYS,
+        default="stage",
+        help="group events by this field (default: stage)",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of table")
+    args = parser.parse_args(argv)
+
+    path = args.log or get_log_path()
+    rows = summarize(path, group_by=args.group_by)
+    if not rows:
+        print(f"no telemetry events found at {path}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(rows, indent=2))
+    else:
+        print(f"telemetry: {path}  ({sum(r['count'] for r in rows)} events)")
+        print(format_table(rows, args.group_by))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agent/telemetry/stage_timer.py
+++ b/agent/telemetry/stage_timer.py
@@ -1,0 +1,117 @@
+"""Stage timing primitive: context manager that appends a JSONL event per stage.
+
+Privacy: only stage name, duration, and coarse labels (provider/model/tool) are
+captured. Never logs prompt content, secrets, or arbitrary user data. Callers
+must pass already-redacted labels.
+
+Usage:
+    from agent.telemetry import StageTimer
+
+    with StageTimer("context_build", provider="deepseek", model="deepseek-chat"):
+        build_context(...)
+
+The log path defaults to ``$HERMES_TELEMETRY_LOG`` or ``~/.hermes/telemetry.jsonl``.
+File writes are best-effort; failures never raise into the hot path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+
+_DEFAULT_LOG = Path.home() / ".hermes" / "telemetry.jsonl"
+_log_path: Optional[Path] = None
+
+
+def set_log_path(path: str | os.PathLike[str]) -> None:
+    """Override the JSONL output path (mainly for tests)."""
+    global _log_path
+    _log_path = Path(path)
+
+
+def get_log_path() -> Path:
+    """Resolve the active JSONL output path."""
+    if _log_path is not None:
+        return _log_path
+    env = os.environ.get("HERMES_TELEMETRY_LOG")
+    return Path(env) if env else _DEFAULT_LOG
+
+
+def record_stage(
+    stage: str,
+    duration_ms: float,
+    *,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    tool: Optional[str] = None,
+    ok: bool = True,
+    meta: Optional[dict[str, Any]] = None,
+) -> None:
+    """Append a single stage event to the JSONL log. Best-effort, never raises."""
+    event = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        "stage": stage,
+        "duration_ms": round(float(duration_ms), 3),
+        "provider": provider,
+        "model": model,
+        "tool": tool,
+        "ok": bool(ok),
+        "meta": meta or {},
+    }
+    try:
+        path = get_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event, ensure_ascii=False) + "\n")
+    except Exception:  # noqa: BLE001 - telemetry must never break runtime
+        return
+
+
+class StageTimer:
+    """Context manager that times a runtime stage and emits a JSONL event.
+
+    Sets ``ok=False`` automatically if the block raises. The exception still
+    propagates; telemetry is side-effect only.
+    """
+
+    __slots__ = ("stage", "provider", "model", "tool", "meta", "_t0", "ok", "duration_ms")
+
+    def __init__(
+        self,
+        stage: str,
+        *,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        tool: Optional[str] = None,
+        meta: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self.stage = stage
+        self.provider = provider
+        self.model = model
+        self.tool = tool
+        self.meta = meta
+        self._t0 = 0.0
+        self.ok = True
+        self.duration_ms = 0.0
+
+    def __enter__(self) -> "StageTimer":
+        self._t0 = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.duration_ms = (time.perf_counter() - self._t0) * 1000.0
+        self.ok = exc_type is None
+        record_stage(
+            self.stage,
+            self.duration_ms,
+            provider=self.provider,
+            model=self.model,
+            tool=self.tool,
+            ok=self.ok,
+            meta=self.meta,
+        )

--- a/docs/perf/dashboard.md
+++ b/docs/perf/dashboard.md
@@ -1,0 +1,92 @@
+# Runtime Performance Dashboard
+
+The telemetry module (`agent/telemetry/`) records per-stage durations from real
+Hermes Turbo Agent runs and renders a local ASCII dashboard for diagnosing
+slow runs. Closes issue #82.
+
+## What gets logged
+
+Every `StageTimer` block appends one JSON line to a JSONL log with the shape:
+
+```json
+{"ts":"2026-05-21T12:34:56.789012Z","stage":"context_build","duration_ms":42.501,"provider":"deepseek","model":"deepseek-chat","tool":null,"ok":true,"meta":{}}
+```
+
+Fields: `ts` (UTC ISO 8601), `stage`, `duration_ms`, optional `provider` /
+`model` / `tool` labels, `ok` (false when the block raised), and free-form
+`meta`.
+
+**Privacy guarantee**: no prompt content, secret, or arbitrary user data is
+written by the timer itself. Callers must keep `meta` redacted.
+
+Default path: `~/.hermes/telemetry.jsonl`. Override with `HERMES_TELEMETRY_LOG`.
+
+## Instrumenting a stage
+
+```python
+from agent.telemetry import StageTimer
+
+with StageTimer("context_build"):
+    build_context(...)
+
+with StageTimer("model_call", provider="deepseek", model="deepseek-chat"):
+    response = call_model(...)
+
+with StageTimer("tool_dispatch", tool="ripgrep"):
+    run_tool(...)
+```
+
+Recommended stage names (extend as needed):
+
+- `context_build` - assembling prompt context
+- `prompt_build` - final prompt rendering
+- `model_call` - LLM HTTP roundtrip
+- `tool_dispatch` - single tool execution
+- `db_write` - persistence
+- `mcp_reload` - MCP server reload
+- `delegation` - sub-agent handoff
+- `retry` - automatic retry attempt
+- `ui_event_burst` - UI event flush
+
+## Reading the dashboard
+
+```bash
+python -m agent.telemetry.dashboard
+python -m agent.telemetry.dashboard --group-by provider
+python -m agent.telemetry.dashboard --group-by model --json
+python -m agent.telemetry.dashboard --log /path/to/telemetry.jsonl
+```
+
+Sample output:
+
+```
+telemetry: /home/wesley/.hermes/telemetry.jsonl  (1284 events)
++----------------+--------+--------+--------+--------+--------+---------+
+| stage          | count  | errors | p50_ms | p95_ms | p99_ms | mean_ms |
++----------------+--------+--------+--------+--------+--------+---------+
+| model_call     | 612    | 4      | 812.50 | 2480.10| 3104.77| 968.42  |
+| context_build  | 612    | 0      | 41.20  | 88.30  | 134.50 | 49.81   |
+| tool_dispatch  | 60     | 1      | 22.10  | 71.40  | 96.20  | 31.05   |
++----------------+--------+--------+--------+--------+--------+---------+
+```
+
+Rows are sorted by p95 descending so the worst tail latency surfaces first.
+
+## Diagnosing a slow run
+
+1. Reproduce the slow run with telemetry enabled (default on).
+2. Run `python -m agent.telemetry.dashboard` to find the dominant stage by p95.
+3. Drill in with `--group-by provider` or `--group-by model` to isolate which
+   backend is the bottleneck.
+4. Use `--group-by tool` to spot a single tool dispatch that dominates.
+5. Compare counts and `errors` columns to detect retry storms.
+
+## Resetting the log
+
+```bash
+rm ~/.hermes/telemetry.jsonl
+# or rotate
+mv ~/.hermes/telemetry.jsonl ~/.hermes/telemetry-$(date +%F).jsonl
+```
+
+No daemon, no shipping to remote - local-only by design.


### PR DESCRIPTION
Tracks #82 — previously closed without commits, reopened to deliver real implementation.

## Scope
Add runtime performance dashboard and stage telemetry

## Status
Scaffold only. Implementation plan in `.plans/issue-82-add-runtime-performance-dashboard-and-stage-telemetry.md`. Will be expanded in follow-up commits until DoD is green.

Refs #82