### PR TITLE
track(#83): Improve token throughput with incremental context and token cache

### DIFF
--- a/.plans/issue-83-improve-token-throughput-with-incremental-context-and-token-.md
+++ b/.plans/issue-83-improve-token-throughput-with-incremental-context-and-token-.md
@@ -1,0 +1,35 @@
+# Issue #83: Improve token throughput with incremental context and token cache
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/83
+
+## Original description (excerpt)
+
+```
+## Goal
+Attack one of the benchmark rows where OpenClaw still wins by making token/context accounting incremental.
+
+## Context
+The current benchmark shows Hermes Turbo Agent is strong overall but OpenClaw still wins token throughput. The next improvement should avoid re-estimating unchanged message and context segments.
+
+## Acceptance criteria
+- Cache token estimates by stable message/content hash.
+- Add incremental context budget calculation for append-only conversation growth.
+- Invalidate safely when model, tokenizer assumptions, or content changes.
+- Add tests for cache correctness and stale-cache avoidance.
+- Add a focused benchmark comparing cached vs uncached token budget paths.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/agent/context/__init__.py
+++ b/agent/context/__init__.py
@@ -1,0 +1,6 @@
+"""Incremental context and token cache utilities (Issue #83)."""
+
+from .incremental import IncrementalContextBuilder, ContextDelta
+from .token_cache import TokenCache
+
+__all__ = ["IncrementalContextBuilder", "ContextDelta", "TokenCache"]

--- a/agent/context/incremental.py
+++ b/agent/context/incremental.py
@@ -1,0 +1,99 @@
+"""Delta-encoded context builder.
+
+Conversation context is append-only most of the time. Re-sending the full
+prompt on every turn is wasteful: the LLM provider already has the prefix in
+its prompt cache and we already tokenized it locally. This module tracks the
+last prefix that was emitted and yields only the new suffix.
+
+Safety:
+- The prefix is identified by a stable SHA-256 of its serialized messages.
+- If the new context diverges from the recorded prefix (edit, branch, model
+  change), the builder transparently falls back to a full rebuild.
+- Reset is automatic when the caller passes a different ``namespace``
+  (e.g. a different conversation id, model, or tokenizer fingerprint).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Iterable, Optional, Sequence
+
+
+def _hash_messages(messages: Sequence[dict]) -> str:
+    """Stable hash over a list of message dicts."""
+    payload = json.dumps(messages, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class ContextDelta:
+    """Result of an incremental build."""
+
+    namespace: str
+    prefix_hash: str
+    new_messages: tuple
+    is_full_rebuild: bool
+
+    @property
+    def has_new_content(self) -> bool:
+        return bool(self.new_messages)
+
+
+@dataclass
+class IncrementalContextBuilder:
+    """Tracks the last emitted prefix per ``namespace`` and emits only deltas.
+
+    A ``namespace`` is any string that scopes a conversation. Convention:
+    ``"{conversation_id}:{model}:{tokenizer_fingerprint}"``. Changing any
+    component invalidates the cached prefix and forces a full rebuild.
+    """
+
+    _prefix_hash_by_ns: dict = field(default_factory=dict)
+    _prefix_len_by_ns: dict = field(default_factory=dict)
+
+    def build(self, namespace: str, messages: Sequence[dict]) -> ContextDelta:
+        """Return the delta for ``messages`` under ``namespace``."""
+        if not messages:
+            return ContextDelta(namespace, "", tuple(), is_full_rebuild=False)
+
+        last_hash = self._prefix_hash_by_ns.get(namespace)
+        last_len = self._prefix_len_by_ns.get(namespace, 0)
+
+        if last_hash and last_len <= len(messages):
+            prefix_now = _hash_messages(list(messages[:last_len]))
+            if prefix_now == last_hash:
+                new = tuple(messages[last_len:])
+                new_hash = _hash_messages(list(messages))
+                self._prefix_hash_by_ns[namespace] = new_hash
+                self._prefix_len_by_ns[namespace] = len(messages)
+                return ContextDelta(
+                    namespace=namespace,
+                    prefix_hash=new_hash,
+                    new_messages=new,
+                    is_full_rebuild=False,
+                )
+
+        # Divergence or first call: full rebuild.
+        full_hash = _hash_messages(list(messages))
+        self._prefix_hash_by_ns[namespace] = full_hash
+        self._prefix_len_by_ns[namespace] = len(messages)
+        return ContextDelta(
+            namespace=namespace,
+            prefix_hash=full_hash,
+            new_messages=tuple(messages),
+            is_full_rebuild=True,
+        )
+
+    def reset(self, namespace: Optional[str] = None) -> None:
+        """Invalidate one namespace (or all if ``namespace`` is None)."""
+        if namespace is None:
+            self._prefix_hash_by_ns.clear()
+            self._prefix_len_by_ns.clear()
+            return
+        self._prefix_hash_by_ns.pop(namespace, None)
+        self._prefix_len_by_ns.pop(namespace, None)
+
+    def known_namespaces(self) -> Iterable[str]:
+        return tuple(self._prefix_hash_by_ns.keys())

--- a/agent/context/token_cache.py
+++ b/agent/context/token_cache.py
@@ -1,0 +1,82 @@
+"""Content-hash keyed LRU token-count cache.
+
+Tokenization is hot on the request path: every turn re-estimates the cost of
+the same system prompt, the same skill docs, the same prior assistant turns.
+This module memoizes ``len(tokenize(content))`` by ``(tokenizer_key, hash)``
+so the second call is a dict lookup.
+
+Cache safety:
+- Keys include a ``tokenizer_key`` (model name or tokenizer fingerprint).
+  Switching tokenizer never returns a stale count.
+- Content is hashed with SHA-256; collisions are not a practical concern.
+- Bounded by ``maxsize``; oldest entries are evicted (LRU).
+- Cleared on ``invalidate()`` or ``invalidate(tokenizer_key=...)``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections import OrderedDict
+from typing import Callable, Optional
+
+
+def _content_hash(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+class TokenCache:
+    """Bounded LRU cache: (tokenizer_key, content_hash) -> token_count."""
+
+    def __init__(self, maxsize: int = 4096) -> None:
+        if maxsize <= 0:
+            raise ValueError("maxsize must be positive")
+        self._maxsize = maxsize
+        self._data: "OrderedDict[tuple, int]" = OrderedDict()
+        self._hits = 0
+        self._misses = 0
+
+    def count(
+        self,
+        content: str,
+        tokenizer_key: str,
+        compute: Callable[[str], int],
+    ) -> int:
+        """Return cached count or compute, store, and return it."""
+        key = (tokenizer_key, _content_hash(content))
+        cached = self._data.get(key)
+        if cached is not None:
+            self._data.move_to_end(key)
+            self._hits += 1
+            return cached
+        self._misses += 1
+        value = int(compute(content))
+        self._data[key] = value
+        self._data.move_to_end(key)
+        if len(self._data) > self._maxsize:
+            self._data.popitem(last=False)
+        return value
+
+    def invalidate(self, tokenizer_key: Optional[str] = None) -> int:
+        """Drop entries. With ``tokenizer_key``, drop only that bucket."""
+        if tokenizer_key is None:
+            n = len(self._data)
+            self._data.clear()
+            return n
+        to_drop = [k for k in self._data if k[0] == tokenizer_key]
+        for k in to_drop:
+            self._data.pop(k, None)
+        return len(to_drop)
+
+    def stats(self) -> dict:
+        total = self._hits + self._misses
+        hit_rate = (self._hits / total) if total else 0.0
+        return {
+            "size": len(self._data),
+            "maxsize": self._maxsize,
+            "hits": self._hits,
+            "misses": self._misses,
+            "hit_rate": hit_rate,
+        }
+
+    def __len__(self) -> int:
+        return len(self._data)

--- a/docs/perf/token-throughput.md
+++ b/docs/perf/token-throughput.md
@@ -1,0 +1,87 @@
+# Token throughput: incremental context and token cache
+
+Tracking issue: [#83](https://github.com/wesleysimplicio/hermes-turbo-agent/issues/83)
+
+## Why this exists
+
+Benchmarks show Hermes Turbo Agent matches or beats peers on most rows but
+loses token-throughput to OpenClaw. Two low-risk wins close that gap:
+
+1. Avoid re-sending the unchanged conversation prefix on every turn.
+2. Avoid re-tokenizing content the agent already saw this session.
+
+Both are pure local optimizations. No new dependency, stdlib only.
+
+## Components
+
+### `agent/context/incremental.py` — `IncrementalContextBuilder`
+
+Tracks the last emitted prefix per `namespace` (recommended layout:
+`{conversation_id}:{model}:{tokenizer_fingerprint}`) and yields a
+`ContextDelta` containing only the new suffix when the prefix matches.
+
+- Match path: `O(prefix_len)` hash of the prior prefix, then slice.
+- Divergence path: full rebuild, no silent stale send. Triggered when the
+  recorded prefix hash no longer matches (edit, branch, rollback) or when
+  the namespace changes (model swap, tokenizer change).
+
+Invalidation:
+
+- `builder.reset(namespace)` — drop one conversation.
+- `builder.reset()` — drop everything.
+- Any divergence in serialized prefix bytes — automatic fallback.
+
+### `agent/context/token_cache.py` — `TokenCache`
+
+Bounded LRU mapping `(tokenizer_key, sha256(content)) -> token_count`.
+
+- `cache.count(content, tokenizer_key, compute)` returns the cached count
+  or runs `compute(content)`, stores, returns.
+- `cache.invalidate()` clears everything;
+  `cache.invalidate(tokenizer_key="deepseek-chat")` clears just that bucket.
+- `cache.stats()` exposes `{size, maxsize, hits, misses, hit_rate}` for
+  benchmarking and dashboards.
+
+## Safety contract
+
+- The token cache is keyed by `tokenizer_key`. Changing model or tokenizer
+  fingerprint cannot return a stale count — different key, miss, recompute.
+- The incremental builder verifies the recorded prefix hash against the new
+  prefix on every call. A drift forces a full rebuild instead of a wrong
+  delta.
+- No I/O, no global state, no threading primitives required for read-mostly
+  per-process usage. Wrap in a lock if you share across threads.
+
+## Suggested integration
+
+```python
+from agent.context import IncrementalContextBuilder, TokenCache
+
+builder = IncrementalContextBuilder()
+cache = TokenCache(maxsize=4096)
+
+def tokens_for(text: str, model: str) -> int:
+    return cache.count(text, tokenizer_key=model, compute=real_tokenize)
+
+delta = builder.build(
+    namespace=f"{conversation_id}:{model}:{tokenizer_version}",
+    messages=conversation,
+)
+if delta.is_full_rebuild:
+    send_full(conversation)
+else:
+    send_appended(delta.new_messages)
+```
+
+## Benchmark plan
+
+A focused micro-benchmark compares:
+
+- Cold path: every turn re-tokenizes and re-serializes full context.
+- Warm path: incremental delta + cached token counts.
+
+Expected outcomes (to be confirmed on bench rig):
+
+- Wall-clock per turn drops once the prefix stabilizes (turn 2+).
+- Token-count math becomes a constant-time hashmap lookup.
+- Memory bounded by `TokenCache.maxsize` + one prefix hash per namespace.


### PR DESCRIPTION
Tracks #83 — previously closed without commits, reopened to deliver real implementation.

## Scope
Improve token throughput with incremental context and token cache

## Status
Scaffold only. Implementation plan in `.plans/issue-83-improve-token-throughput-with-incremental-context-and-token-.md`. Will be expanded in follow-up commits until DoD is green.

Refs #83