### PR TITLE
track(#84): Evaluate optional Rust or Tokio sidecar for high-concurrency gateway paths

### DIFF
--- a/.plans/issue-84-evaluate-optional-rust-or-tokio-sidecar-for-high-concurrency.md
+++ b/.plans/issue-84-evaluate-optional-rust-or-tokio-sidecar-for-high-concurrency.md
@@ -1,0 +1,35 @@
+# Issue #84: Evaluate optional Rust or Tokio sidecar for high-concurrency gateway paths
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/84
+
+## Original description (excerpt)
+
+```
+## Goal
+Explore a credible path to close the pure async scheduler gap where Node/libuv still wins.
+
+## Context
+`uvloop` improves real Python async paths, but the README and win plan acknowledge that a synthetic 1,000-task scheduler benchmark can still favor OpenClaw. A Rust/Tokio sidecar may be the right optional architecture for high-concurrency gateway workloads.
+
+## Acceptance criteria
+- Write an ADR comparing pure Python/uvloop, Node/libuv, and Rust/Tokio sidecar options.
+- Identify which gateway paths would benefit without complicating normal CLI usage.
+- Prototype only if the ADR shows a clear, bounded path.
+- Keep the sidecar optional and disabled by default.
+- Define benchmark and correctness gates before implementation.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/.specs/architecture/ADR-rust-tokio-sidecar.md
+++ b/.specs/architecture/ADR-rust-tokio-sidecar.md
@@ -1,0 +1,133 @@
+# ADR: Optional Rust/Tokio Sidecar for High-Concurrency Gateway Paths
+
+- Status: Proposed
+- Date: 2026-05-21
+- Refs: #84
+- Supersedes: -
+
+## Context
+
+The Tota Agent gateway aggregates traffic from 20+ messaging platforms
+(Telegram, WhatsApp, Discord, Slack, Matrix, Signal, webhook, api_server, ...).
+Most production workloads are I/O-bound and well served by Python `asyncio`
+plus `uvloop`. However, a synthetic 1,000-task scheduler benchmark still shows
+Node/libuv and Rust/Tokio outperforming pure Python for fan-out, timer-heavy,
+and cross-platform broadcast workloads. Issue #84 asks whether an **optional,
+disabled-by-default** sidecar can close that gap without complicating the
+default CLI experience.
+
+This ADR compares three credible paths and recommends one.
+
+## Decision drivers
+
+- p50/p99 latency under sustained 1k+ concurrent tasks
+- Throughput ceiling (tasks/s) on a single 4-core gateway node
+- Build/packaging cost (wheels, cross-compile, supply chain)
+- Operational cost (process supervision, logs, health, upgrade)
+- Blast radius if the sidecar fails (must degrade to pure Python)
+- Maintenance surface (people who can debug it)
+
+## Options
+
+### Option A - Pure Python `asyncio` + `uvloop` (status quo plus tuning)
+
+Keep everything in-process. Tune: `uvloop.install()`, bounded
+`asyncio.Semaphore` per platform, replace `asyncio.gather` with
+`TaskGroup`, batch DB writes, push hot loops into the existing
+`hermes_fast` Rust extension via PyO3.
+
+- Pros: zero new process, single deploy artifact, debuggable with stdlib
+  tracing, packaging unchanged, contributors already fluent.
+- Cons: GIL still bounds CPU-bound coalescing; scheduler still loses the
+  synthetic 1k-task benchmark by roughly 30-50% vs Tokio; tail latency
+  spikes during GC pauses remain.
+
+### Option B - Rust + PyO3 sidecar in-process (`hermes_fast_gateway`)
+
+Extend the existing `hermes_fast` Rust extension with a Tokio runtime that
+owns the hot loop (fan-out, timers, retry queues, rate limiters). Python
+keeps platform adapters and business logic; Rust exposes async functions via
+PyO3 + `pyo3-async-runtimes`.
+
+- Pros: no second process to supervise; shares logger/config; can be a/b
+  toggled by feature flag; reuses Tota's existing Rust build pipeline; FFI
+  overhead is sub-microsecond.
+- Cons: PyO3 + Tokio bridging is non-trivial (GIL handoff, cancellation
+  semantics); a Rust panic still kills the Python process unless wrapped in
+  `catch_unwind`; manylinux/musllinux wheel matrix expands; debugging
+  segfaults requires `gdb`/`lldb`, not every contributor has the toolchain.
+
+### Option C - Standalone Tokio service with gRPC bridge (`tota-gateway-rs`)
+
+Ship a separate Rust binary speaking gRPC (or Unix-socket length-prefixed
+protobuf). Python gateway becomes a thin proxy when the env var
+`TOTA_GATEWAY_SIDECAR=1` is set; otherwise it stays in-process.
+
+- Pros: full process isolation (panic != user-visible crash); independent
+  release cycle; can be deployed on a different host for horizontal scale;
+  benchmark gains land closest to theoretical max because Python's GIL is
+  out of the hot path entirely.
+- Cons: two binaries to package, supervise (systemd unit, log rotation,
+  health probe), and upgrade in lockstep on schema change; gRPC adds
+  ~10-30us per message; CLI users now have a second daemon to install or
+  Docker image gets a multi-stage build; debugging crosses a process
+  boundary.
+
+## Comparison
+
+| Dimension              | A (pure Python)    | B (PyO3 sidecar)   | C (gRPC sidecar)   |
+| ---------------------- | ------------------ | ------------------ | ------------------ |
+| Expected p50 @ 1k task | baseline           | -30% to -50%       | -50% to -65%       |
+| Expected p99 @ 1k task | baseline           | -20% to -40%       | -40% to -55%       |
+| Throughput ceiling     | baseline           | 2-3x               | 3-5x               |
+| Build complexity       | none               | medium (wheels)    | high (2 artifacts) |
+| Ops complexity         | none               | low                | medium-high        |
+| Blast radius isolation | n/a                | weak (in-process)  | strong (process)   |
+| Optional + off default | trivial            | feature flag       | env-var gated      |
+| CLI UX impact          | none               | none               | one extra daemon   |
+| Contributor reach      | broad              | narrow (Rust)      | narrow (Rust+gRPC) |
+
+Numbers are directional estimates from published Tokio/uvloop benchmarks and
+must be replaced by repo-local numbers from `docs/perf/sidecar-benchmark-plan.md`
+before any prototype merges.
+
+## Decision
+
+**Recommend Option B (PyO3 sidecar) as the prototype path, contingent on the
+benchmark plan in `docs/perf/sidecar-benchmark-plan.md` producing a >=30%
+p99 reduction on the gateway hot loops listed there.**
+
+Rationale: B keeps the single-binary CLI promise that ships Tota today,
+reuses the Rust toolchain Hermes already maintains for `hermes_fast`, and
+closes most of the gap without a second daemon. C remains an explicit
+follow-up if and only if B fails the panic-isolation gate or if a customer
+emerges who needs horizontal sidecar scaling.
+
+A stays the baseline and shipping default. The sidecar is loaded only when
+`TOTA_FAST_GATEWAY=1` is set; absent the flag, behavior must be
+byte-identical to today.
+
+## Consequences
+
+- New optional dependency: `pyo3-async-runtimes` and a Tokio-based crate
+  inside the existing `hermes_fast` workspace.
+- Wheel matrix gains one Rust feature flag; CI must build both with and
+  without it.
+- A correctness gate (parity test suite) must run both code paths against
+  the same input and assert byte-identical outputs before any release with
+  the flag flipped to default-on.
+- If the benchmark fails the >=30% p99 gate, the prototype is discarded
+  and this ADR is superseded by one that locks in Option A indefinitely.
+
+## Alternatives considered
+
+- Node/libuv sidecar: rejected - adds a third language runtime and Node's
+  GC pause profile is not obviously better than Python's for this workload.
+- `multiprocessing` + shared memory: rejected - IPC cost dwarfs the
+  scheduler win; we measured this in #62.
+
+## Follow-up
+
+- Implement `docs/perf/sidecar-benchmark-plan.md` first.
+- Open a prototype issue gated on benchmark results.
+- If approved, write ADR for Option C as the horizontal-scale path.

--- a/docs/perf/sidecar-benchmark-plan.md
+++ b/docs/perf/sidecar-benchmark-plan.md
@@ -1,0 +1,91 @@
+# Sidecar Benchmark Plan
+
+Companion to `.specs/architecture/ADR-rust-tokio-sidecar.md`. Defines the
+methodology that gates whether Option B (Rust+PyO3 sidecar) is prototyped
+beyond the ADR. No prototype work begins until this plan runs against the
+current `main` and produces numbers stored under `docs/perf/results/`.
+
+## Scope
+
+Three workloads, run in this order. Each must complete on a 4-core / 8 GB
+node before promoting to a larger box.
+
+1. **Synthetic 1k-task fan-out** - the original benchmark cited in #84.
+   Spawn N async tasks, each does `await asyncio.sleep(jitter)` then a
+   shared in-memory increment. N in {100, 500, 1000, 5000}.
+2. **Gateway broadcast** - replay a recorded burst of 200 inbound messages
+   across 5 platforms with platform-specific rate limits enforced.
+3. **Retry storm** - inject 10% failures upstream and measure scheduler
+   behavior under exponential backoff with jitter.
+
+## Variants
+
+Run each workload against three builds, same hardware, same kernel:
+
+- `A` - current `main` with `uvloop` enabled.
+- `B` - prototype branch with `TOTA_FAST_GATEWAY=1` (PyO3 sidecar).
+- `C` - sibling experiment with the standalone Tokio sidecar over Unix
+  socket gRPC. Optional; run only if B clears its gate.
+
+## Metrics
+
+Capture for each `(workload, variant)` cell. Five runs, drop high+low,
+report median + IQR.
+
+| Metric                  | Unit       | How                                          |
+| ----------------------- | ---------- | -------------------------------------------- |
+| p50 task latency        | ms         | per-task wall clock from spawn to completion |
+| p99 task latency        | ms         | same                                         |
+| p99.9 task latency      | ms         | same                                         |
+| Throughput              | tasks/s    | total tasks / wall time                      |
+| CPU utilization         | % per core | `psutil` per process, 100ms samples          |
+| RSS peak                | MB         | `psutil` peak across run                     |
+| GC pause max (Python)   | ms         | `gc.callbacks` instrumentation               |
+| FFI overhead (B only)   | us         | tracing span around PyO3 boundary            |
+| IPC overhead (C only)   | us         | tracing span around gRPC call                |
+| Crash / panic count     | int        | must be 0; non-zero fails the gate           |
+
+## Correctness gate (must pass before perf is even considered)
+
+A parity test replays the gateway broadcast workload through both `A` and
+`B`, captures every outbound message in order with timestamp truncated to
+1ms, and asserts identical message bodies and identical send order per
+platform. Any divergence fails the gate.
+
+## Success criteria
+
+Option B is approved for prototype if **all** of the following hold:
+
+- p99 task latency on workload 1 (N=1000): `B` is at least **30% lower**
+  than `A`.
+- p99 task latency on workload 2: `B` is at least **20% lower** than `A`.
+- Throughput on workload 1 (N=1000): `B` is at least **2x** `A`.
+- Correctness gate passes on workloads 1, 2, and 3.
+- No panic, no segfault, no Python-side `RuntimeError` from the bridge.
+- RSS peak: `B` <= 1.5x `A`.
+- FFI overhead median <= 5us per call.
+
+Option C is greenlit only if B fails *and* a customer use case demands
+horizontal scaling.
+
+## Tooling
+
+- Bench harness: `pytest-benchmark` for in-process; `wrk2`-style custom
+  driver for the broadcast workload.
+- Metric capture: `pytest-benchmark` JSON + custom CSV writer; results
+  land in `docs/perf/results/<date>/` and are checked into the repo.
+- Tracing: `opentelemetry-sdk` with a no-op exporter in default builds.
+
+## Out of scope
+
+- Multi-host scale-out (covered by future ADR for Option C).
+- Persistent queue backpressure under disk-full conditions.
+- Cold-start latency of the sidecar (measured separately if B ships).
+
+## Open questions
+
+- Is `pyo3-async-runtimes` stable enough on Python 3.13t (free-threading)?
+- Does `manylinux2014` still cover our target distros, or do we need
+  `manylinux_2_28`?
+- How do we expose the new metrics to the existing observability plugin
+  without changing its schema?


### PR DESCRIPTION
Tracks #84 — previously closed without commits, reopened to deliver real implementation.

## Scope
Evaluate optional Rust or Tokio sidecar for high-concurrency gateway paths

## Status
Scaffold only. Implementation plan in `.plans/issue-84-evaluate-optional-rust-or-tokio-sidecar-for-high-concurrency.md`. Will be expanded in follow-up commits until DoD is green.

Refs #84