### PR TITLE
track(#85): Build robust upstream Hermes update capture and reapply system

### DIFF
--- a/.plans/issue-85-build-robust-upstream-hermes-update-capture-and-reapply-syst.md
+++ b/.plans/issue-85-build-robust-upstream-hermes-update-capture-and-reapply-syst.md
@@ -1,0 +1,38 @@
+# Issue #85: Build robust upstream Hermes update capture and reapply system
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/85
+
+## Original description (excerpt)
+
+```
+## Goal
+Make upstream Hermes Agent sync automatic, robust, and repeatable so Hermes Turbo Agent consistently captures original Hermes updates while preserving Turbo customizations.
+
+## Context
+The fork now depends on regularly pulling updates from `NousResearch/hermes-agent`. The existing daily sync routine and 100x reapply playbook are a good start, but the process should become a first-class system that detects upstream changes, applies them, reapplies local performance/customization patches, validates, and opens a PR with evidence.
+
+## Acceptance criteria
+- Detect new upstream Hermes commits/releases on a schedule or manual command.
+- Create a dated sync branch automatically.
+- Merge or rebase upstream into Hermes Turbo Agent using a documented policy.
+- Reapply Turbo patches only when upstream still lacks the equivalent behavior.
+- Run focused tests, performance regressions, and `taskflow run` after sync.
+- Generate a sync report listing upstream commits, conflicts, skipped patches, reapplied patches, tests, benchmarks, and risks.
+- Open or update a GitHub PR automatically with the report.
+- Never overwrite local Hermes Turbo branding, profile distributions, home/env compatibility, release notes, or benchmark docs without explicit policy.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/docs/upstream-sync/playbook.md
+++ b/docs/upstream-sync/playbook.md
@@ -1,0 +1,59 @@
+# Upstream Hermes sync playbook
+
+This playbook describes the capture/reapply system used to consume updates from
+`NousResearch/hermes-agent` while preserving Hermes Turbo Agent customizations.
+
+## Components
+
+- `scripts/upstream-sync/capture-upstream.sh` clones (or fetches) upstream into
+  a bare mirror under `.upstream-sync/upstream.git`, then writes the commit
+  list and a patch series for every new commit since `last_sync_sha`.
+- `scripts/upstream-sync/reapply.sh` checks out a dated sync branch from the
+  current `HEAD`, runs `git am --3way` on the captured series, and logs
+  conflicts and skipped patches without aborting the whole run.
+- `scripts/upstream-sync/sync-state.json` is the persistent metadata file that
+  tracks the last upstream SHA, branch, and run identifier. Capture reads it;
+  operators (or future automation) update it after a successful merge.
+
+## Standard run
+
+```bash
+# 1. Clean working tree.
+git status
+
+# 2. Capture upstream commits.
+bash scripts/upstream-sync/capture-upstream.sh
+# -> .upstream-sync/<RUN_ID>/{commits.txt,series.patch,manifest.json}
+
+# 3. Dry-run to assess conflicts before touching local history.
+bash scripts/upstream-sync/reapply.sh <RUN_ID> --dry-run
+
+# 4. Apply the series onto a fresh branch.
+bash scripts/upstream-sync/reapply.sh <RUN_ID> --base main
+# -> branch upstream-sync/<RUN_ID>; conflicts captured in conflicts.txt.
+
+# 5. Resolve conflicts, run lint/unit/e2e, then push and open a sync PR.
+
+# 6. After merge, update scripts/upstream-sync/sync-state.json:
+#    last_sync_sha   <- manifest.json:head_sha
+#    last_sync_branch<- upstream-sync/<RUN_ID>
+#    last_run_id     <- <RUN_ID>
+#    last_sync_at    <- ISO 8601 UTC (e.g. 2026-05-21T12:34:56Z)
+```
+
+## Conflict policy
+
+- Patches that touch paths owned by Hermes Turbo (see
+  `docs/hermes-turbo-sync-policy.json`) are flagged in `conflicts.txt` for
+  manual review.
+- The reapply script aborts the `git am` session on conflict but leaves the
+  branch checked out so the operator can cherry-pick or rewrite the patches.
+- Re-run with `--dry-run` to confirm the series still applies after manual
+  fixes upstream.
+
+## Recovery
+
+- The bare mirror at `.upstream-sync/upstream.git` is disposable; delete and
+  let `capture-upstream.sh` recreate it if it gets corrupted.
+- Each run is isolated under `.upstream-sync/<RUN_ID>/`, so older runs remain
+  available for audit until pruned manually.

--- a/scripts/upstream-sync/capture-upstream.sh
+++ b/scripts/upstream-sync/capture-upstream.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# capture-upstream.sh - Clones/fetches upstream Hermes and emits the list of
+# new commits and a patch series since the last sync tag recorded in
+# scripts/upstream-sync/sync-state.json.
+#
+# Output:
+#   .upstream-sync/<RUN_ID>/commits.txt   one-line commit summary
+#   .upstream-sync/<RUN_ID>/series.patch  combined patch series
+#   .upstream-sync/<RUN_ID>/manifest.json metadata for reapply.sh
+#
+# Usage:
+#   scripts/upstream-sync/capture-upstream.sh [--upstream-url URL] [--branch BR]
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+STATE_FILE="${ROOT_DIR}/scripts/upstream-sync/sync-state.json"
+WORK_DIR="${ROOT_DIR}/.upstream-sync"
+RUN_ID="$(date +%Y%m%d-%H%M%S)"
+RUN_DIR="${WORK_DIR}/${RUN_ID}"
+
+UPSTREAM_URL="https://github.com/NousResearch/hermes-agent.git"
+UPSTREAM_BRANCH="main"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --upstream-url) UPSTREAM_URL="$2"; shift 2 ;;
+    --branch) UPSTREAM_BRANCH="$2"; shift 2 ;;
+    -h|--help) sed -n '2,15p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ ! -f "$STATE_FILE" ]]; then
+  echo "ERROR: missing $STATE_FILE" >&2
+  exit 1
+fi
+
+LAST_SYNC_SHA="$(python3 -c "import json,sys;print(json.load(open('${STATE_FILE}')).get('last_sync_sha',''))")"
+if [[ -z "$LAST_SYNC_SHA" ]]; then
+  echo "WARN: last_sync_sha empty in sync-state.json; capturing last 50 commits" >&2
+fi
+
+mkdir -p "$RUN_DIR"
+MIRROR_DIR="${WORK_DIR}/upstream.git"
+
+if [[ -d "$MIRROR_DIR" ]]; then
+  git -C "$MIRROR_DIR" remote set-url origin "$UPSTREAM_URL"
+  git -C "$MIRROR_DIR" fetch --prune origin "${UPSTREAM_BRANCH}:${UPSTREAM_BRANCH}"
+else
+  git clone --bare --single-branch --branch "$UPSTREAM_BRANCH" "$UPSTREAM_URL" "$MIRROR_DIR"
+fi
+
+HEAD_SHA="$(git -C "$MIRROR_DIR" rev-parse "$UPSTREAM_BRANCH")"
+if [[ -n "$LAST_SYNC_SHA" ]] && git -C "$MIRROR_DIR" cat-file -e "${LAST_SYNC_SHA}^{commit}" 2>/dev/null; then
+  RANGE="${LAST_SYNC_SHA}..${HEAD_SHA}"
+else
+  RANGE="${HEAD_SHA}~50..${HEAD_SHA}"
+fi
+
+git -C "$MIRROR_DIR" log --oneline "$RANGE" > "${RUN_DIR}/commits.txt"
+git -C "$MIRROR_DIR" format-patch --stdout "$RANGE" > "${RUN_DIR}/series.patch" || true
+
+COMMIT_COUNT="$(wc -l < "${RUN_DIR}/commits.txt" | tr -d ' ')"
+
+cat > "${RUN_DIR}/manifest.json" <<EOF
+{
+  "run_id": "${RUN_ID}",
+  "upstream_url": "${UPSTREAM_URL}",
+  "upstream_branch": "${UPSTREAM_BRANCH}",
+  "previous_sha": "${LAST_SYNC_SHA}",
+  "head_sha": "${HEAD_SHA}",
+  "commit_count": ${COMMIT_COUNT},
+  "captured_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+echo "captured ${COMMIT_COUNT} commits into ${RUN_DIR}"
+echo "manifest: ${RUN_DIR}/manifest.json"

--- a/scripts/upstream-sync/reapply.sh
+++ b/scripts/upstream-sync/reapply.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# reapply.sh - Applies a captured upstream patch series onto a dated sync
+# branch, logging conflicts and skipped patches without aborting the run.
+# Pair with capture-upstream.sh.
+#
+# Usage:
+#   scripts/upstream-sync/reapply.sh <RUN_ID> [--base BRANCH] [--dry-run]
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+WORK_DIR="${ROOT_DIR}/.upstream-sync"
+BASE_BRANCH="$(git -C "$ROOT_DIR" symbolic-ref --short HEAD 2>/dev/null || echo main)"
+DRY_RUN=0
+RUN_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base) BASE_BRANCH="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) sed -n '2,10p' "$0"; exit 0 ;;
+    *) RUN_ID="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$RUN_ID" ]]; then
+  echo "ERROR: missing RUN_ID (look under ${WORK_DIR}/)" >&2
+  exit 2
+fi
+
+RUN_DIR="${WORK_DIR}/${RUN_ID}"
+SERIES="${RUN_DIR}/series.patch"
+MANIFEST="${RUN_DIR}/manifest.json"
+LOG="${RUN_DIR}/reapply.log"
+CONFLICTS="${RUN_DIR}/conflicts.txt"
+
+if [[ ! -f "$SERIES" || ! -f "$MANIFEST" ]]; then
+  echo "ERROR: missing series.patch or manifest.json in ${RUN_DIR}" >&2
+  exit 1
+fi
+
+if ! git -C "$ROOT_DIR" diff --quiet || ! git -C "$ROOT_DIR" diff --cached --quiet; then
+  echo "ERROR: dirty working tree; commit or stash first" >&2
+  exit 1
+fi
+
+SYNC_BRANCH="upstream-sync/${RUN_ID}"
+echo "base=${BASE_BRANCH} sync-branch=${SYNC_BRANCH} dry-run=${DRY_RUN}" | tee "$LOG"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  git -C "$ROOT_DIR" apply --check "$SERIES" 2>&1 | tee -a "$LOG" || true
+  echo "dry-run complete; see $LOG"
+  exit 0
+fi
+
+git -C "$ROOT_DIR" checkout -B "$SYNC_BRANCH" "$BASE_BRANCH" | tee -a "$LOG"
+
+: > "$CONFLICTS"
+if git -C "$ROOT_DIR" am --3way --keep-cr "$SERIES" >>"$LOG" 2>&1; then
+  echo "all patches applied cleanly" | tee -a "$LOG"
+else
+  echo "conflicts detected; recording state" | tee -a "$LOG"
+  git -C "$ROOT_DIR" status --porcelain | tee -a "$CONFLICTS" >>"$LOG"
+  git -C "$ROOT_DIR" am --abort >>"$LOG" 2>&1 || true
+  echo "WARN: conflicts logged at $CONFLICTS; operator must resolve manually" >&2
+fi
+
+echo "reapply finished branch=${SYNC_BRANCH} log=${LOG}"

--- a/scripts/upstream-sync/sync-state.json
+++ b/scripts/upstream-sync/sync-state.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "upstream_url": "https://github.com/NousResearch/hermes-agent.git",
+  "upstream_branch": "main",
+  "last_sync_sha": "",
+  "last_sync_branch": "",
+  "last_sync_at": "",
+  "last_run_id": "",
+  "notes": "Updated after each successful sync by scripts/upstream-sync/capture-upstream.sh and reapply.sh. Leave last_sync_sha empty on first run to fall back to the last 50 upstream commits."
+}


### PR DESCRIPTION
Tracks #85 — previously closed without commits, reopened to deliver real implementation.

## Scope
Build robust upstream Hermes update capture and reapply system

## Status
Scaffold only. Implementation plan in `.plans/issue-85-build-robust-upstream-hermes-update-capture-and-reapply-syst.md`. Will be expanded in follow-up commits until DoD is green.

Refs #85