### PR TITLE
track(#86): Add upstream sync policy file for Hermes Turbo customizations

### DIFF
--- a/.plans/issue-86-add-upstream-sync-policy-file-for-hermes-turbo-customization.md
+++ b/.plans/issue-86-add-upstream-sync-policy-file-for-hermes-turbo-customization.md
@@ -1,0 +1,35 @@
+# Issue #86: Add upstream sync policy file for Hermes Turbo customizations
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/86
+
+## Original description (excerpt)
+
+```
+## Goal
+Codify what the upstream sync system should keep, prefer, merge, or regenerate during Hermes Agent updates.
+
+## Context
+A robust update system needs policy, not only scripts. The fork has branding, aliases, desktop/car profiles, performance patches, benchmark docs, and compatibility layers that must survive upstream refreshes.
+
+## Acceptance criteria
+- Add a machine-readable sync policy file under docs or config.
+- Classify paths as `keep-turbo`, `prefer-upstream`, `merge`, `regenerate`, or `manual-review`.
+- Include explicit rules for branding, CLI aliases, profile distributions, `HERMES_TURBO_HOME`, benchmark docs/assets, and performance patches.
+- Add validation that the policy references existing paths or accepted glob patterns.
+- Document how to update the policy when new fork-owned areas are added.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/.upstream-sync-policy.yml
+++ b/.upstream-sync-policy.yml
@@ -1,0 +1,121 @@
+# Upstream Sync Policy (declarative, root-level)
+#
+# Companion to docs/hermes-turbo-sync-policy.json. This YAML file is the
+# human-edited entry point for the policy that governs how Hermes Turbo
+# absorbs upstream Hermes Agent refreshes.
+#
+# Strategies:
+#   keep-turbo       - Fork wins. Upstream changes ignored unless rule is updated.
+#   prefer-upstream  - Upstream wins. Override only via narrower rule.
+#   merge            - Combine: upstream behavior layered onto fork-owned surface.
+#   regenerate       - Derived artifact. Rebuild from source after sync.
+#   manual-review    - No auto-merge. Human compares against latest runtime.
+#
+# Format docs and update workflow: docs/upstream-sync/policy.md
+# Validator: scripts/validate_sync_policy.py
+version: 1
+updated_for_issue: 86
+owner: wesleysimplicio/hermes-turbo-agent
+
+update_process:
+  - "When a new fork-owned area is introduced, add a rule here before the next upstream sync."
+  - "Run `python scripts/validate_sync_policy.py` in CI and before merging sync automation changes."
+  - "Prefer the narrowest rule that explains ownership; use `manual-review` until a stable strategy is proven."
+
+rules:
+  - name: brand-and-launch-assets
+    strategy: keep-turbo
+    reason: >-
+      Fork identity, README positioning, launch site, and brand image assets
+      must survive upstream refreshes unchanged unless the fork intentionally
+      rebrands again.
+    paths:
+      - README.md
+      - tota-agent.html
+      - docs/assets/tota-brand/**
+      - docs/tota-social-storyboard.md
+      - docs/tota-identity-customization.md
+
+  - name: fork-home-aliases-and-entrypoints
+    strategy: merge
+    reason: >-
+      CLI aliases, HERMES_TURBO_HOME environment variables, and startup
+      wrappers must absorb upstream behavior while retaining Tota/Hermes-Turbo
+      entrypoints.
+    paths:
+      - hermes
+      - hermes_constants.py
+      - hermes_cli/main.py
+      - run_agent.py
+      - AGENTS.md
+
+  - name: profile-distribution-and-warmup-surface
+    strategy: merge
+    reason: >-
+      Desktop and car profile logic is fork-owned behavior layered on top of
+      upstream CLI/runtime changes.
+    paths:
+      - hermes_cli/profiles.py
+      - hermes_cli/profile_distribution.py
+      - gateway/status.py
+      - gateway/run.py
+
+  - name: llm-project-mapper-core-onboarding
+    strategy: keep-turbo
+    reason: >-
+      Project mapping is a fork policy and should not be dropped by an
+      upstream sync.
+    paths:
+      - agent/auto_mapper.py
+      - agent/prompt_builder.py
+      - skills/software-development/llm-project-mapper/**
+      - tests/test_auto_mapper.py
+      - tests/test_map_project_skill.py
+
+  - name: upstream-owned-core-and-site
+    strategy: prefer-upstream
+    reason: >-
+      General upstream surfaces default to Hermes unless another narrower
+      rule overrides them.
+    paths:
+      - website/**
+      - gateway/platforms/**
+      - plugins/**
+      - tests/**
+    allow_empty_globs:
+      - gateway/platforms/**
+
+  - name: benchmark-measurements-and-derived-assets
+    strategy: regenerate
+    reason: >-
+      Benchmark JSON is the source of truth; markdown, battle cards, PDFs,
+      and stale markers must be regenerated only from measured output after
+      sync.
+    paths:
+      - docs/tota-benchmark-hermes-0.14.0.json
+      - docs/tota-benchmark-hermes-0.14.0.md
+      - docs/assets/tota-benchmark/battles/**
+      - tota_agent_benchmark_report.pdf
+      - docs/benchmark-refresh-status.json
+      - docs/benchmark-refresh-status.md
+    allow_missing_paths:
+      - docs/benchmark-refresh-status.json
+      - docs/benchmark-refresh-status.md
+    allow_empty_globs:
+      - docs/assets/tota-benchmark/battles/**
+
+  - name: performance-patches-and-budgets
+    strategy: manual-review
+    reason: >-
+      Fast-path patches and performance budgets are intentionally divergent;
+      every upstream sync must review them against the latest measured
+      runtime behavior.
+    paths:
+      - agent/_fastjson.py
+      - agent/_hermes_fast.py
+      - agent/uvloop_utils.py
+      - scripts/benchmark_runtime_usage.py
+      - scripts/benchmark_startup_perf.py
+      - scripts/perf_budgets.py
+      - scripts/perf_budgets.json
+      - .github/workflows/perf-budgets.yml

--- a/docs/upstream-sync/policy.md
+++ b/docs/upstream-sync/policy.md
@@ -1,0 +1,86 @@
+# Upstream Sync Policy
+
+This document explains the format of `/.upstream-sync-policy.yml` (root) and
+how to keep it aligned with the JSON twin at
+`docs/hermes-turbo-sync-policy.json`.
+
+## Why two files
+
+| File                                | Purpose                                                                     |
+| ----------------------------------- | --------------------------------------------------------------------------- |
+| `.upstream-sync-policy.yml` (root)  | Declarative, human-edited entry point. Easy to diff in PR reviews.          |
+| `docs/hermes-turbo-sync-policy.json` | Machine twin consumed by `scripts/validate_sync_policy.py` and CI.          |
+
+When a rule changes, edit the YAML first, then mirror it into the JSON.
+A follow-up task may collapse the two by teaching the validator to read YAML
+directly; until then the JSON is authoritative for tooling.
+
+## Top-level fields
+
+```yaml
+version: 1                  # bump on incompatible schema change
+updated_for_issue: 86       # GitHub issue that last touched the policy
+owner: wesleysimplicio/...  # repo slug
+update_process: []          # ordered list of human instructions
+rules: []                   # ordered list of rule objects (see below)
+```
+
+## Rule object
+
+```yaml
+- name: short-kebab-id            # unique within file
+  strategy: keep-turbo            # one of the five strategies below
+  reason: >-                      # one to three sentences, present tense
+    Why this rule exists.
+  paths:                          # list of exact paths or glob patterns
+    - some/file.py
+    - some/dir/**
+  allow_empty_globs: []           # optional: globs that may match nothing
+  allow_missing_paths: []         # optional: exact paths that may not exist
+```
+
+## Strategies
+
+| Strategy          | Behavior during sync                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| `keep-turbo`      | Fork wins. Upstream changes ignored unless this rule is rewritten.                   |
+| `prefer-upstream` | Upstream wins. Use the narrowest other rule to carve out fork-owned exceptions.      |
+| `merge`           | Combine upstream behavior on top of fork-owned surface (manual merge or 3-way tool). |
+| `regenerate`      | Derived artifact. Rebuild from the source rule after sync (e.g. benchmark markdown). |
+| `manual-review`   | No automation. A human compares fork vs upstream against latest runtime measurement. |
+
+Pick the narrowest strategy that explains the file's ownership. Default to
+`manual-review` when ownership is unclear.
+
+## Path semantics
+
+- Exact paths must exist in the working tree unless listed under
+  `allow_missing_paths`.
+- Glob patterns (`**`, `*`, `?`) must match at least one tracked file unless
+  listed under `allow_empty_globs`.
+- Rules are evaluated in order; the first matching rule wins for a given
+  path. Put narrower rules above broader ones.
+
+## How to update
+
+1. Edit `/.upstream-sync-policy.yml` first. Add or modify rules.
+2. Mirror the change into `docs/hermes-turbo-sync-policy.json` (same fields,
+   same order).
+3. Run `python scripts/validate_sync_policy.py` locally.
+4. Validate YAML loads cleanly:
+   `python3 -c 'import yaml; yaml.safe_load(open(".upstream-sync-policy.yml"))'`.
+5. Commit both files together. Reference the issue or ADR in the commit body.
+
+## When to add a new rule
+
+- A new fork-owned directory or file appears (skill, profile, asset bundle).
+- An upstream area becomes safe to default to `prefer-upstream` after enough
+  proof.
+- A `manual-review` rule has been observed stable for two sync cycles and can
+  graduate to `merge`.
+
+## Out of scope
+
+- Secret material. The policy file ships in git; never reference unencrypted
+  secrets here.
+- One-shot migrations. Use an ADR plus a dated runbook, not a policy rule.


### PR DESCRIPTION
Tracks #86 — previously closed without commits, reopened to deliver real implementation.

## Scope
Add upstream sync policy file for Hermes Turbo customizations

## Status
Scaffold only. Implementation plan in `.plans/issue-86-add-upstream-sync-policy-file-for-hermes-turbo-customization.md`. Will be expanded in follow-up commits until DoD is green.

Refs #86