### PR TITLE
track(#87): Create benchmark refresh workflow after upstream sync

### DIFF
--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -1,0 +1,46 @@
+name: Benchmark Refresh
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "sync/**"
+      - "upstream-sync/**"
+      - "codex/tota-hermes-daily-*"
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package and benchmark dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[all,dev,fast]" || python -m pip install -e .
+          python -m pip install reportlab cairosvg
+
+      - name: Run benchmark refresh
+        id: refresh
+        run: bash scripts/benchmarks/refresh.sh
+        env:
+          BENCHMARK_RESULTS_DIR: benchmarks/results
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmarks/results/
+          if-no-files-found: warn
+          retention-days: 90

--- a/.plans/issue-87-create-benchmark-refresh-workflow-after-upstream-sync.md
+++ b/.plans/issue-87-create-benchmark-refresh-workflow-after-upstream-sync.md
@@ -1,0 +1,35 @@
+# Issue #87: Create benchmark refresh workflow after upstream sync
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/87
+
+## Original description (excerpt)
+
+```
+## Goal
+Keep performance claims current whenever Hermes Turbo Agent absorbs upstream Hermes changes.
+
+## Context
+After each upstream sync, README tables, benchmark JSON/Markdown/PDF, battle cards, and 100x docs may become stale. The project needs a repeatable refresh workflow that updates claims only after measurement.
+
+## Acceptance criteria
+- Add a command or workflow that runs the benchmark suite after upstream sync.
+- Refresh machine-readable benchmark outputs first.
+- Regenerate Markdown/PDF/cards only from measured data.
+- Mark benchmarks as stale if refresh cannot complete.
+- Include benchmark deltas in the upstream sync PR body.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/docs/perf/benchmark-refresh.md
+++ b/docs/perf/benchmark-refresh.md
@@ -1,0 +1,49 @@
+# Benchmark Refresh After Upstream Sync
+
+Keeps Hermes Turbo Agent performance claims grounded in measurement after every
+upstream Hermes sync.
+
+## Trigger
+
+The `Benchmark Refresh` workflow (`.github/workflows/benchmark-refresh.yml`)
+runs on:
+
+- `workflow_dispatch` — manual run from the Actions tab.
+- `push` to `sync/**`, `upstream-sync/**`, and `codex/tota-hermes-daily-*`
+  branches (the branch patterns used by upstream sync automation).
+
+## What it does
+
+1. Checks out the repository and installs the package plus benchmark/report
+   dependencies (`reportlab`, `cairosvg`).
+2. Runs `scripts/benchmarks/refresh.sh`, which invokes the existing Python
+   benchmark runner (`scripts/refresh_sync_benchmarks.py`) and captures its
+   output.
+3. Writes a machine-readable JSON file per run to
+   `benchmarks/results/<YYYY-MM-DD>.json` (UTC date). Fields:
+
+   | Field    | Type   | Description                                  |
+   | -------- | ------ | -------------------------------------------- |
+   | `date`   | string | UTC date in `YYYY-MM-DD` format.             |
+   | `commit` | string | Git SHA of the synced commit.                |
+   | `ref`    | string | Branch ref the refresh ran against.          |
+   | `status` | string | `ok` if benchmarks passed, `stale` on error. |
+   | `runner` | string | Path to the runner script (provenance).      |
+   | `log`    | string | Captured stdout/stderr of the runner.        |
+
+4. Uploads the entire `benchmarks/results/` directory as the
+   `benchmark-results` workflow artifact (90-day retention).
+
+## Stale runs
+
+If the benchmark runner is missing or exits non-zero, the JSON record carries
+`"status": "stale"` and the workflow emits a `::warning::` annotation. Markdown,
+PDF, and battle-card regeneration must consume only records with
+`"status": "ok"`.
+
+## Surfacing deltas in sync PRs
+
+The upstream sync PR body should link to the most recent
+`benchmarks/results/<date>.json` artifact and include the diff of measured
+metrics versus the previous record. Stale records block the PR's performance
+claim section until a clean refresh exists.

--- a/scripts/benchmarks/refresh.sh
+++ b/scripts/benchmarks/refresh.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Refresh benchmark suite after upstream sync.
+# Writes machine-readable results to ${BENCHMARK_RESULTS_DIR}/<UTC date>.json.
+# Marks the run as "stale" if the underlying benchmark script fails.
+set -euo pipefail
+
+RESULTS_DIR="${BENCHMARK_RESULTS_DIR:-benchmarks/results}"
+DATE_UTC="$(date -u +%F)"
+COMMIT_SHA="${GITHUB_SHA:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
+REF_NAME="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}"
+OUT_FILE="${RESULTS_DIR}/${DATE_UTC}.json"
+
+mkdir -p "${RESULTS_DIR}"
+
+STATUS="ok"
+RAW_OUTPUT=""
+if command -v python >/dev/null 2>&1 && [ -f scripts/refresh_sync_benchmarks.py ]; then
+  if RAW_OUTPUT="$(python scripts/refresh_sync_benchmarks.py --python python 2>&1)"; then
+    STATUS="ok"
+  else
+    STATUS="stale"
+  fi
+else
+  STATUS="stale"
+  RAW_OUTPUT="benchmark runner unavailable: missing python or scripts/refresh_sync_benchmarks.py"
+fi
+
+ESCAPED_OUTPUT="$(printf '%s' "${RAW_OUTPUT}" | python -c 'import json,sys; sys.stdout.write(json.dumps(sys.stdin.read()))' 2>/dev/null || printf '""')"
+
+cat >"${OUT_FILE}" <<EOF
+{
+  "date": "${DATE_UTC}",
+  "commit": "${COMMIT_SHA}",
+  "ref": "${REF_NAME}",
+  "status": "${STATUS}",
+  "runner": "scripts/benchmarks/refresh.sh",
+  "log": ${ESCAPED_OUTPUT}
+}
+EOF
+
+echo "Wrote ${OUT_FILE} (status=${STATUS})"
+if [ "${STATUS}" = "stale" ]; then
+  echo "::warning::Benchmark refresh marked stale; see ${OUT_FILE}"
+fi


### PR DESCRIPTION
Tracks #87 — previously closed without commits, reopened to deliver real implementation.

## Scope
Create benchmark refresh workflow after upstream sync

## Status
Scaffold only. Implementation plan in `.plans/issue-87-create-benchmark-refresh-workflow-after-upstream-sync.md`. Will be expanded in follow-up commits until DoD is green.

Refs #87