### PR TITLE
track(#88): Add native token-saver proxy for shell and tool output

### DIFF
--- a/.plans/issue-88-add-native-token-saver-proxy-for-shell-and-tool-output.md
+++ b/.plans/issue-88-add-native-token-saver-proxy-for-shell-and-tool-output.md
@@ -1,0 +1,35 @@
+# Issue #88: Add native token-saver proxy for shell and tool output
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/88
+
+## Original description (excerpt)
+
+```
+## Goal
+Add a Hermes Turbo native token-saver layer inspired by RTK-style CLI output compression, reducing noisy shell/tool output before it enters model context.
+
+## Context
+RTK (`rtk-ai/rtk`) positions itself as a CLI proxy that rewrites common commands and compresses outputs such as `git status`, `git diff`, test runners, Docker, Kubernetes, and GitHub CLI. Hermes Turbo should offer a native equivalent for its own runtime instead of relying only on external hooks.
+
+## Acceptance criteria
+- Add a token-saver abstraction for command/tool output before it is appended to conversation context.
+- Support command-aware adapters for at least `git status`, `git diff`, `git log`, `rg`, `pytest`, `ruff`, `npm test`, and generic long logs.
+- Provide modes: `off`, `safe`, `balanced`, and `aggressive`.
+- Preserve error details and file/line references in `safe` and `balanced` modes.
+- Include tests proving compressed output keeps the actionable signal needed for debugging.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/agent/token_saver/__init__.py
+++ b/agent/token_saver/__init__.py
@@ -1,0 +1,13 @@
+"""Hermes Turbo native token-saver proxy.
+
+Provides command/tool output compression before content enters model context.
+See ``proxy`` for the head/tail truncation strategy and file-backed handles.
+"""
+
+from agent.token_saver.proxy import (
+    TokenSaverProxy,
+    TruncationResult,
+    truncate_output,
+)
+
+__all__ = ["TokenSaverProxy", "TruncationResult", "truncate_output"]

--- a/agent/token_saver/proxy.py
+++ b/agent/token_saver/proxy.py
@@ -1,0 +1,153 @@
+"""Native token-saver proxy for shell and tool output.
+
+Wraps long command/tool output before it enters model context. Strategy is a
+simple head/tail truncation at ``max_lines``: keep the first ``head`` lines and
+the last ``tail`` lines, drop the middle, and persist the full payload to a
+file. The caller receives the truncated text together with a handle string of
+the form ``<handle:/abs/path/to/file>`` that can be used to fetch the full
+output on demand.
+
+The proxy is intentionally minimal -- it is the foundation for the broader
+RTK-style command-aware adapters tracked in issue #88 (``git diff``, ``pytest``,
+etc.). Adapters land in follow-up commits; this module nails the truncation and
+handle contract first so they can build on top.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_MAX_LINES = 200
+DEFAULT_HEAD = 80
+DEFAULT_TAIL = 80
+_TRUNCATION_MARKER_PREFIX = "... [token-saver] truncated"
+
+
+@dataclass
+class TruncationResult:
+    """Outcome of a single truncation pass."""
+
+    text: str
+    handle: Optional[str] = None
+    full_path: Optional[str] = None
+    original_line_count: int = 0
+    kept_line_count: int = 0
+    truncated: bool = False
+    meta: dict = field(default_factory=dict)
+
+
+def _format_handle(path: str) -> str:
+    return f"<handle:{path}>"
+
+
+def _persist_full(text: str, storage_dir: Path) -> str:
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha1(text.encode("utf-8", errors="replace")).hexdigest()[:12]
+    timestamp = int(time.time() * 1000)
+    target = storage_dir / f"output-{timestamp}-{digest}.txt"
+    target.write_text(text, encoding="utf-8")
+    return str(target)
+
+
+def truncate_output(
+    text: str,
+    *,
+    max_lines: int = DEFAULT_MAX_LINES,
+    head: int = DEFAULT_HEAD,
+    tail: int = DEFAULT_TAIL,
+    storage_dir: Optional[Path] = None,
+) -> TruncationResult:
+    """Apply head/tail truncation to ``text``.
+
+    - Returns the text unchanged when it has ``max_lines`` or fewer lines.
+    - When truncated, persists the full payload to ``storage_dir`` (defaults to
+      a stable subdirectory under the system temp dir) and returns a ``handle``
+      pointing at the absolute path.
+    - The visible payload contains the first ``head`` lines, a truncation
+      marker reporting how many lines were elided, and the last ``tail`` lines.
+    """
+    if max_lines <= 0:
+        raise ValueError("max_lines must be > 0")
+    if head < 0 or tail < 0:
+        raise ValueError("head and tail must be >= 0")
+    if head + tail > max_lines:
+        raise ValueError("head + tail must be <= max_lines")
+
+    lines = text.splitlines()
+    original_line_count = len(lines)
+
+    if original_line_count <= max_lines:
+        return TruncationResult(
+            text=text,
+            original_line_count=original_line_count,
+            kept_line_count=original_line_count,
+            truncated=False,
+        )
+
+    storage = storage_dir or Path(tempfile.gettempdir()) / "hermes-token-saver"
+    full_path = _persist_full(text, storage)
+    handle = _format_handle(full_path)
+
+    head_slice = lines[:head] if head else []
+    tail_slice = lines[-tail:] if tail else []
+    elided = original_line_count - len(head_slice) - len(tail_slice)
+    marker = (
+        f"{_TRUNCATION_MARKER_PREFIX} {elided} lines "
+        f"(full output: {handle})"
+    )
+
+    kept = head_slice + [marker] + tail_slice
+    return TruncationResult(
+        text="\n".join(kept),
+        handle=handle,
+        full_path=full_path,
+        original_line_count=original_line_count,
+        kept_line_count=len(head_slice) + len(tail_slice),
+        truncated=True,
+        meta={"head": len(head_slice), "tail": len(tail_slice), "elided": elided},
+    )
+
+
+class TokenSaverProxy:
+    """Stateful wrapper that applies truncation to shell/tool outputs."""
+
+    def __init__(
+        self,
+        *,
+        max_lines: int = DEFAULT_MAX_LINES,
+        head: int = DEFAULT_HEAD,
+        tail: int = DEFAULT_TAIL,
+        storage_dir: Optional[Path] = None,
+    ) -> None:
+        self.max_lines = max_lines
+        self.head = head
+        self.tail = tail
+        self.storage_dir = (
+            storage_dir or Path(tempfile.gettempdir()) / "hermes-token-saver"
+        )
+
+    def wrap(self, text: str) -> TruncationResult:
+        return truncate_output(
+            text,
+            max_lines=self.max_lines,
+            head=self.head,
+            tail=self.tail,
+            storage_dir=self.storage_dir,
+        )
+
+    def resolve(self, handle: str) -> str:
+        """Read the full payload for a previously emitted ``handle``."""
+        prefix = "<handle:"
+        if not (handle.startswith(prefix) and handle.endswith(">")):
+            raise ValueError(f"not a token-saver handle: {handle!r}")
+        path = handle[len(prefix) : -1]
+        if not os.path.isfile(path):
+            raise FileNotFoundError(path)
+        return Path(path).read_text(encoding="utf-8")

--- a/docs/perf/token-saver-proxy.md
+++ b/docs/perf/token-saver-proxy.md
@@ -1,0 +1,70 @@
+# Token-saver proxy (native)
+
+Native Hermes Turbo layer that compresses shell and tool output before it is
+appended to model context. Lives in `agent/token_saver/`.
+
+## What it does
+
+- Counts lines in the captured output.
+- Below `max_lines`: returns the text untouched.
+- Above `max_lines`: keeps the first `head` lines, drops the middle, keeps the
+  last `tail` lines, and inserts a single truncation marker in between.
+- Writes the full payload to a file under the configured `storage_dir` and
+  exposes it as `<handle:/abs/path/to/output-<ts>-<sha>.txt>` so callers can
+  pull the complete log when they actually need it.
+
+## Why head/tail
+
+Shell tools (`pytest`, `git diff`, `npm test`, long `rg`) follow a recurring
+pattern: the interesting signal sits at the top (banner / summary / first
+failure) and the bottom (final assertion, exit code, totals). The noisy middle
+is what blows the context budget. Head/tail is the smallest strategy that
+preserves both ends without inventing parser-specific rules per command --
+those land as adapters on top of this proxy in follow-up commits.
+
+## Usage
+
+```python
+from agent.token_saver import TokenSaverProxy
+
+proxy = TokenSaverProxy(max_lines=200, head=80, tail=80)
+result = proxy.wrap(captured_stdout)
+
+# Feed the compact view back to the model:
+context_chunk = result.text
+
+# Later, when the model asks for the full log:
+if result.handle:
+    full = proxy.resolve(result.handle)
+```
+
+`TruncationResult` carries the visible `text`, the `handle` (or `None`), the
+`full_path` on disk, original/kept line counts, and a `meta` dict with the
+head/tail/elided split.
+
+## Defaults
+
+| Field         | Value                                              |
+| ------------- | -------------------------------------------------- |
+| `max_lines`   | 200                                                |
+| `head`        | 80                                                 |
+| `tail`        | 80                                                 |
+| `storage_dir` | `${TMPDIR}/hermes-token-saver`                     |
+| Handle form   | `<handle:/abs/path/output-<ts>-<sha1[:12]>.txt>`   |
+
+Invariants enforced at call time: `max_lines > 0`, `head >= 0`, `tail >= 0`,
+`head + tail <= max_lines`.
+
+## Out of scope (tracked separately)
+
+- Command-aware adapters for `git status`, `git diff`, `git log`, `rg`,
+  `pytest`, `ruff`, `npm test` -- they build on top of `TokenSaverProxy` and
+  ship as follow-ups under issue #88.
+- `off / safe / balanced / aggressive` profile presets -- next iteration.
+- TTL / garbage collection on `storage_dir` -- intentionally manual for now.
+
+## Tests
+
+`tests/token_saver/test_proxy.py` covers head/tail boundary conditions, handle
+creation and resolution, invalid argument handling, and the round-trip from
+`wrap()` to `resolve()`.

--- a/tests/token_saver/test_proxy.py
+++ b/tests/token_saver/test_proxy.py
@@ -1,0 +1,127 @@
+"""Unit tests for ``agent.token_saver.proxy``."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from agent.token_saver.proxy import (
+    DEFAULT_HEAD,
+    DEFAULT_MAX_LINES,
+    DEFAULT_TAIL,
+    TokenSaverProxy,
+    truncate_output,
+)
+
+
+def _make_lines(n: int) -> str:
+    return "\n".join(f"line-{i:04d}" for i in range(n))
+
+
+class TestTruncateOutput:
+    def test_under_threshold_returns_unchanged(self, tmp_path: Path) -> None:
+        text = _make_lines(10)
+        result = truncate_output(
+            text, max_lines=50, head=10, tail=10, storage_dir=tmp_path
+        )
+        assert result.truncated is False
+        assert result.text == text
+        assert result.handle is None
+        assert result.full_path is None
+        assert result.original_line_count == 10
+        assert result.kept_line_count == 10
+        assert list(tmp_path.iterdir()) == []
+
+    def test_exact_threshold_is_not_truncated(self, tmp_path: Path) -> None:
+        text = _make_lines(50)
+        result = truncate_output(
+            text, max_lines=50, head=10, tail=10, storage_dir=tmp_path
+        )
+        assert result.truncated is False
+        assert result.text == text
+
+    def test_above_threshold_keeps_head_and_tail(self, tmp_path: Path) -> None:
+        text = _make_lines(500)
+        result = truncate_output(
+            text, max_lines=100, head=20, tail=30, storage_dir=tmp_path
+        )
+        assert result.truncated is True
+        kept_lines = result.text.split("\n")
+        assert len(kept_lines) == 20 + 1 + 30
+        assert kept_lines[0] == "line-0000"
+        assert kept_lines[19] == "line-0019"
+        assert kept_lines[-1] == "line-0499"
+        assert kept_lines[-30] == "line-0470"
+        marker = kept_lines[20]
+        assert "truncated" in marker
+        assert "<handle:" in marker
+        assert result.meta == {"head": 20, "tail": 30, "elided": 450}
+
+    def test_handle_points_to_file_with_full_output(self, tmp_path: Path) -> None:
+        text = _make_lines(300)
+        result = truncate_output(
+            text, max_lines=50, head=10, tail=10, storage_dir=tmp_path
+        )
+        assert result.handle is not None
+        assert result.full_path is not None
+        match = re.match(r"^<handle:(.+)>$", result.handle)
+        assert match is not None
+        assert match.group(1) == result.full_path
+        assert Path(result.full_path).read_text(encoding="utf-8") == text
+
+    def test_head_only_no_tail(self, tmp_path: Path) -> None:
+        text = _make_lines(100)
+        result = truncate_output(
+            text, max_lines=30, head=30, tail=0, storage_dir=tmp_path
+        )
+        assert result.truncated is True
+        kept = result.text.split("\n")
+        assert kept[:30] == [f"line-{i:04d}" for i in range(30)]
+        assert kept[-1].startswith("... [token-saver] truncated")
+
+    def test_tail_only_no_head(self, tmp_path: Path) -> None:
+        text = _make_lines(100)
+        result = truncate_output(
+            text, max_lines=30, head=0, tail=30, storage_dir=tmp_path
+        )
+        assert result.truncated is True
+        kept = result.text.split("\n")
+        assert kept[0].startswith("... [token-saver] truncated")
+        assert kept[-30:] == [f"line-{i:04d}" for i in range(70, 100)]
+
+    def test_invalid_args_raise(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError):
+            truncate_output("x", max_lines=0, storage_dir=tmp_path)
+        with pytest.raises(ValueError):
+            truncate_output(
+                "x", max_lines=10, head=-1, tail=5, storage_dir=tmp_path
+            )
+        with pytest.raises(ValueError):
+            truncate_output(
+                "x", max_lines=10, head=8, tail=8, storage_dir=tmp_path
+            )
+
+
+class TestTokenSaverProxy:
+    def test_wrap_and_resolve_round_trip(self, tmp_path: Path) -> None:
+        proxy = TokenSaverProxy(
+            max_lines=20, head=5, tail=5, storage_dir=tmp_path
+        )
+        text = _make_lines(200)
+        result = proxy.wrap(text)
+        assert result.truncated is True
+        assert result.handle is not None
+        assert proxy.resolve(result.handle) == text
+
+    def test_resolve_rejects_bad_handle(self, tmp_path: Path) -> None:
+        proxy = TokenSaverProxy(storage_dir=tmp_path)
+        with pytest.raises(ValueError):
+            proxy.resolve("not-a-handle")
+        with pytest.raises(FileNotFoundError):
+            proxy.resolve("<handle:/nonexistent/path/output.txt>")
+
+    def test_defaults_are_reasonable(self) -> None:
+        assert DEFAULT_MAX_LINES > 0
+        assert DEFAULT_HEAD + DEFAULT_TAIL <= DEFAULT_MAX_LINES


### PR DESCRIPTION
Tracks #88 — previously closed without commits, reopened to deliver real implementation.

## Scope
Add native token-saver proxy for shell and tool output

## Status
Scaffold only. Implementation plan in `.plans/issue-88-add-native-token-saver-proxy-for-shell-and-tool-output.md`. Will be expanded in follow-up commits until DoD is green.

Refs #88