### PR TITLE
track(#90): Add GitHub and CI token-optimized adapters

### DIFF
--- a/.plans/issue-90-add-github-and-ci-token-optimized-adapters.md
+++ b/.plans/issue-90-add-github-and-ci-token-optimized-adapters.md
@@ -1,0 +1,35 @@
+# Issue #90: Add GitHub and CI token-optimized adapters
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/90
+
+## Original description (excerpt)
+
+```
+## Goal
+Make GitHub issue/PR/check workflows token-efficient by summarizing the high-signal parts of `gh` and CI output.
+
+## Context
+A lot of agent token burn comes from `gh issue view`, `gh pr view`, `gh pr checks`, `gh run view --log`, and verbose CI logs. Hermes Turbo should prefer compact summaries and let the agent expand only the failing step or relevant thread.
+
+## Acceptance criteria
+- Add adapters for `gh issue list/view`, `gh pr list/view/checks`, and GitHub Actions logs.
+- Group CI failures by job, step, file, line, and error signature.
+- Strip duplicated logs, progress noise, and low-signal metadata.
+- Preserve links, issue/PR numbers, check names, failing commands, and timestamps when relevant.
+- Add fixtures for noisy GitHub/CI output and compression tests.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/agent/adapters/__init__.py
+++ b/agent/adapters/__init__.py
@@ -1,0 +1,6 @@
+"""Token-optimized adapters package.
+
+Submodules:
+- ``github_compact``: slim views over ``gh`` CLI output.
+- ``ci_compact``: failing-stage-only summaries of CI logs.
+"""

--- a/agent/adapters/ci_compact.py
+++ b/agent/adapters/ci_compact.py
@@ -1,0 +1,170 @@
+"""Token-optimized CI log parser.
+
+Reads raw GitHub Actions / generic CI log text and returns only the
+failing stages plus a short first-error excerpt per stage. Designed to
+turn megabytes of `gh run view --log` output into a handful of lines.
+Stdlib-only.
+
+Refs #90.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+# GitHub Actions log line shape:
+#   <Job>\t<step>\t<timestamp> <message>
+# We are intentionally permissive — we accept either tab-delimited GHA
+# output or plain log lines from any CI.
+_GHA_LINE = re.compile(
+    r"^(?P<job>[^\t]+)\t(?P<step>[^\t]+)\t"
+    r"(?P<ts>\S+)\s+(?P<msg>.*)$"
+)
+
+_ERROR_MARKERS = re.compile(
+    r"(?i)\b(error|fatal|failed|failure|traceback|exception|panic|assert(ion)?)\b"
+    r"|^##\[error\]|^E\s+|^\s*FAIL\b"
+)
+
+# Higher-signal markers — used to upgrade the chosen signature when the
+# first match is a low-signal line like "test_bar FAILED".
+_STRONG_MARKERS = re.compile(
+    r"(?i)^##\[error\]|^E\s+|\b(traceback|assert(ion)?error|exception|panic|fatal)\b"
+)
+
+_NOISE_PREFIXES = (
+    "##[group]",
+    "##[endgroup]",
+    "##[debug]",
+    "::group::",
+    "::endgroup::",
+    "::debug::",
+)
+
+_PROGRESS_PATTERNS = re.compile(
+    r"^\s*(Downloading|Receiving objects|Resolving deltas|"
+    r"\[\d+/\d+\]|Progress:|\d+%\s)"
+)
+
+_EXCERPT_LINES = 5
+
+
+def _strip_ts(line: str) -> str:
+    """Strip a leading ISO timestamp like `2024-05-20T12:34:56.789Z `."""
+    return re.sub(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z?\s+", "", line)
+
+
+def _is_noise(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return True
+    if stripped.startswith(_NOISE_PREFIXES):
+        return True
+    if _PROGRESS_PATTERNS.match(stripped):
+        return True
+    return False
+
+
+def _parse_line(line: str) -> Tuple[Optional[str], Optional[str], str]:
+    """Return (job, step, message). Job/step are None for non-GHA lines."""
+    m = _GHA_LINE.match(line)
+    if m:
+        return m.group("job"), m.group("step"), m.group("msg")
+    return None, None, _strip_ts(line)
+
+
+def parse_ci_log(text: str) -> Dict[str, Any]:
+    """Group a CI log by (job, step) and return failing stages only.
+
+    Returns a dict shaped like::
+
+        {
+            "failing": [
+                {
+                    "job": "build",
+                    "step": "pytest",
+                    "first_error_line": 142,
+                    "excerpt": "...\\n...",
+                    "signature": "AssertionError: expected 1 got 2",
+                }
+            ],
+            "stats": {"total_lines": 4321, "stages_seen": 7, "stages_failing": 1},
+        }
+    """
+    lines = text.splitlines()
+    stages: Dict[Tuple[Optional[str], Optional[str]], Dict[str, Any]] = {}
+
+    for idx, raw in enumerate(lines, start=1):
+        if _is_noise(raw):
+            continue
+        job, step, msg = _parse_line(raw)
+        key = (job, step)
+        stage = stages.setdefault(key, {
+            "job": job,
+            "step": step,
+            "first_error_line": None,
+            "error_lines": [],
+            "signature": None,
+        })
+        if _ERROR_MARKERS.search(msg):
+            if stage["first_error_line"] is None:
+                stage["first_error_line"] = idx
+                stage["signature"] = _first_signature(msg)
+            elif _STRONG_MARKERS.search(msg) and not _STRONG_MARKERS.search(
+                stage["signature"] or ""
+            ):
+                # Upgrade a weak signature ("test_x FAILED") to a strong one.
+                stage["signature"] = _first_signature(msg)
+            if len(stage["error_lines"]) < _EXCERPT_LINES:
+                stage["error_lines"].append(msg.rstrip())
+
+    failing = []
+    for stage in stages.values():
+        if stage["first_error_line"] is None:
+            continue
+        failing.append({
+            "job": stage["job"],
+            "step": stage["step"],
+            "first_error_line": stage["first_error_line"],
+            "excerpt": "\n".join(stage["error_lines"]),
+            "signature": stage["signature"],
+        })
+
+    return {
+        "failing": failing,
+        "stats": {
+            "total_lines": len(lines),
+            "stages_seen": len(stages),
+            "stages_failing": len(failing),
+        },
+    }
+
+
+def _first_signature(msg: str) -> str:
+    """Best-effort short signature: the bit after the first marker."""
+    cleaned = msg.strip()
+    cleaned = re.sub(r"^##\[error\]\s*", "", cleaned)
+    cleaned = re.sub(r"^E\s+", "", cleaned)
+    return cleaned[:160]
+
+
+def summarize_runs(runs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Compact `gh run list --json ...` output, keeping only failing runs."""
+    out = []
+    for r in runs:
+        conclusion = (r.get("conclusion") or "").lower()
+        status = (r.get("status") or "").lower()
+        if conclusion in {"success", "skipped", "neutral"}:
+            continue
+        if not conclusion and status in {"", "completed"}:
+            continue
+        out.append({
+            "id": r.get("databaseId") or r.get("id"),
+            "name": r.get("name") or r.get("workflowName"),
+            "conclusion": conclusion or r.get("status"),
+            "headBranch": r.get("headBranch"),
+            "url": r.get("url"),
+            "createdAt": r.get("createdAt"),
+        })
+    return out

--- a/agent/adapters/github_compact.py
+++ b/agent/adapters/github_compact.py
@@ -1,0 +1,162 @@
+"""Token-optimized adapter for `gh` CLI output.
+
+Wraps `gh issue|pr|run` calls and returns slim JSON containing only
+high-signal fields. Large bodies are replaced with short previews plus a
+content-hash handle that can be re-resolved on demand via an evidence
+store. Stdlib-only.
+
+Refs #90.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from typing import Any, Dict, Iterable, List, Optional
+
+_BODY_PREVIEW_CHARS = 240
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha1(text.encode("utf-8", "ignore")).hexdigest()[:12]
+
+
+def _body_handle(body: Optional[str]) -> Dict[str, Any]:
+    """Replace a long body with a preview + handle for later expansion."""
+    if not body:
+        return {"preview": "", "handle": None, "chars": 0}
+    body_str = body.strip()
+    return {
+        "preview": body_str[:_BODY_PREVIEW_CHARS],
+        "handle": f"body:{_hash(body_str)}",
+        "chars": len(body_str),
+    }
+
+
+def _run_gh(args: List[str], gh_bin: str = "gh") -> str:
+    """Invoke `gh` and return stdout. Raises on non-zero exit."""
+    proc = subprocess.run(
+        [gh_bin, *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout
+
+
+def _resolve_gh(gh_bin: str) -> str:
+    if shutil.which(gh_bin) is None:
+        raise FileNotFoundError(f"gh binary not found: {gh_bin}")
+    return gh_bin
+
+
+def compact_issue(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Compact a single `gh issue view --json ...` payload."""
+    return {
+        "number": raw.get("number"),
+        "title": raw.get("title"),
+        "state": raw.get("state"),
+        "url": raw.get("url"),
+        "author": (raw.get("author") or {}).get("login"),
+        "labels": [l.get("name") for l in (raw.get("labels") or []) if l.get("name")],
+        "comments": len(raw.get("comments") or []),
+        "body": _body_handle(raw.get("body")),
+        "updatedAt": raw.get("updatedAt"),
+    }
+
+
+def compact_issue_list(raw: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Compact `gh issue list --json ...` output."""
+    return [
+        {
+            "number": i.get("number"),
+            "title": i.get("title"),
+            "state": i.get("state"),
+            "labels": [l.get("name") for l in (i.get("labels") or []) if l.get("name")],
+            "url": i.get("url"),
+        }
+        for i in raw
+    ]
+
+
+def compact_pr(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Compact `gh pr view --json ...` payload."""
+    return {
+        "number": raw.get("number"),
+        "title": raw.get("title"),
+        "state": raw.get("state"),
+        "isDraft": raw.get("isDraft"),
+        "url": raw.get("url"),
+        "author": (raw.get("author") or {}).get("login"),
+        "baseRef": raw.get("baseRefName"),
+        "headRef": raw.get("headRefName"),
+        "additions": raw.get("additions"),
+        "deletions": raw.get("deletions"),
+        "changedFiles": raw.get("changedFiles"),
+        "mergeable": raw.get("mergeable"),
+        "body": _body_handle(raw.get("body")),
+        "reviewDecision": raw.get("reviewDecision"),
+    }
+
+
+def compact_pr_checks(raw: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    """Compact `gh pr checks --json ...` payload.
+
+    Highlights failing checks; success checks are returned as a count only.
+    """
+    failing: List[Dict[str, Any]] = []
+    passing = 0
+    pending = 0
+    for c in raw:
+        state = (c.get("state") or c.get("conclusion") or "").upper()
+        bucket = (c.get("bucket") or "").lower()
+        is_fail = state in {"FAILURE", "FAILED", "ERROR", "TIMED_OUT"} or bucket == "fail"
+        is_pending = state in {"PENDING", "IN_PROGRESS", "QUEUED"} or bucket == "pending"
+        if is_fail:
+            failing.append({
+                "name": c.get("name"),
+                "state": state or bucket,
+                "url": c.get("link") or c.get("detailsUrl"),
+                "workflow": c.get("workflow"),
+            })
+        elif is_pending:
+            pending += 1
+        else:
+            passing += 1
+    return {"failing": failing, "passing": passing, "pending": pending}
+
+
+def gh_issue_compact(number: int, repo: Optional[str] = None, gh_bin: str = "gh") -> Dict[str, Any]:
+    """Run `gh issue view <n> --json ...` and return the compact form."""
+    _resolve_gh(gh_bin)
+    args = [
+        "issue", "view", str(number),
+        "--json", "number,title,state,url,author,labels,comments,body,updatedAt",
+    ]
+    if repo:
+        args += ["--repo", repo]
+    return compact_issue(json.loads(_run_gh(args, gh_bin)))
+
+
+def gh_pr_compact(number: int, repo: Optional[str] = None, gh_bin: str = "gh") -> Dict[str, Any]:
+    """Run `gh pr view <n>` + checks and return the compact form."""
+    _resolve_gh(gh_bin)
+    pr_args = [
+        "pr", "view", str(number),
+        "--json",
+        "number,title,state,isDraft,url,author,baseRefName,headRefName,"
+        "additions,deletions,changedFiles,mergeable,body,reviewDecision",
+    ]
+    check_args = ["pr", "checks", str(number), "--json", "name,state,bucket,workflow,link"]
+    if repo:
+        pr_args += ["--repo", repo]
+        check_args += ["--repo", repo]
+    pr = compact_pr(json.loads(_run_gh(pr_args, gh_bin)))
+    try:
+        checks_raw = json.loads(_run_gh(check_args, gh_bin))
+    except subprocess.CalledProcessError:
+        checks_raw = []
+    pr["checks"] = compact_pr_checks(checks_raw)
+    return pr

--- a/docs/perf/compact-adapters.md
+++ b/docs/perf/compact-adapters.md
@@ -1,0 +1,77 @@
+# Compact GitHub & CI Adapters
+
+Token-optimized wrappers for `gh` CLI output and CI logs. They turn the
+high-volume `gh issue/pr view`, `gh pr checks`, and `gh run view --log`
+streams into slim JSON payloads suitable for direct inclusion in an
+agent prompt.
+
+## Modules
+
+- `agent/adapters/github_compact.py` — wraps `gh` invocations and
+  returns only high-signal fields (number, title, state, url, labels,
+  diff stats, etc.). Long issue/PR bodies are replaced with a
+  240-character preview plus a `body:<sha1>` handle that points to the
+  full body in the evidence store.
+- `agent/adapters/ci_compact.py` — parses raw CI log text and returns
+  only the failing stages (job + step) with a short excerpt of the
+  first error and a signature line. Strips `##[group]` markers,
+  progress bars, debug output and other low-signal noise.
+
+## Usage
+
+```python
+from agent.adapters.github_compact import gh_issue_compact, gh_pr_compact
+from agent.adapters.ci_compact import parse_ci_log
+
+issue = gh_issue_compact(90, repo="wesleysimplicio/hermes-turbo-agent")
+pr = gh_pr_compact(115, repo="wesleysimplicio/hermes-turbo-agent")
+log = open("run.log").read()
+summary = parse_ci_log(log)
+```
+
+## Output shape
+
+`gh_issue_compact`:
+
+```json
+{
+  "number": 90,
+  "title": "...",
+  "state": "OPEN",
+  "url": "...",
+  "author": "alice",
+  "labels": ["perf"],
+  "comments": 3,
+  "body": {"preview": "first 240 chars...", "handle": "body:abc123", "chars": 2000},
+  "updatedAt": "2024-05-20T12:00:00Z"
+}
+```
+
+`parse_ci_log`:
+
+```json
+{
+  "failing": [{
+    "job": "build",
+    "step": "pytest",
+    "first_error_line": 142,
+    "excerpt": "##[error]AssertionError...",
+    "signature": "AssertionError: expected 1 got 2"
+  }],
+  "stats": {"total_lines": 4321, "stages_seen": 7, "stages_failing": 1}
+}
+```
+
+## Design notes
+
+- Stdlib only. No new dependencies.
+- Body handles are content-addressed (`sha1[:12]`) so identical bodies
+  collapse to the same handle across runs.
+- The CI parser is permissive: it accepts the tab-delimited GHA log
+  format as well as plain log lines from any CI.
+- Errors are detected by a curated marker regex (`error`, `fatal`,
+  `traceback`, `##[error]`, `E   ` etc.) plus a `FAIL` keyword. The
+  excerpt is capped at 5 lines per stage so a 50k-line stack trace
+  collapses to a handful of bytes.
+
+Refs #90.

--- a/tests/test_ci_compact.py
+++ b/tests/test_ci_compact.py
@@ -1,0 +1,78 @@
+"""Unit tests for agent.adapters.ci_compact."""
+
+from __future__ import annotations
+
+from agent.adapters.ci_compact import parse_ci_log, summarize_runs
+
+
+GHA_NOISY_LOG = """\
+build\tCheckout\t2024-05-20T12:00:00.000Z ##[group]Run actions/checkout@v4
+build\tCheckout\t2024-05-20T12:00:00.100Z Receiving objects: 12% (120/1000)
+build\tCheckout\t2024-05-20T12:00:00.200Z Receiving objects: 100% (1000/1000)
+build\tCheckout\t2024-05-20T12:00:00.300Z ##[endgroup]
+build\tpytest\t2024-05-20T12:00:01.000Z Running 42 tests
+build\tpytest\t2024-05-20T12:00:01.500Z test_foo PASSED
+build\tpytest\t2024-05-20T12:00:02.000Z test_bar FAILED
+build\tpytest\t2024-05-20T12:00:02.100Z ##[error]AssertionError: expected 1 got 2
+build\tpytest\t2024-05-20T12:00:02.200Z   File "x.py", line 10, in test_bar
+build\tpytest\t2024-05-20T12:00:02.300Z     assert 1 == 2
+e2e\tplaywright\t2024-05-20T12:00:05.000Z 12 passed in 30s
+"""
+
+
+def test_parse_ci_log_returns_only_failing_stages():
+    out = parse_ci_log(GHA_NOISY_LOG)
+    assert out["stats"]["stages_failing"] == 1
+    assert len(out["failing"]) == 1
+    failing = out["failing"][0]
+    assert failing["job"] == "build"
+    assert failing["step"] == "pytest"
+    assert "AssertionError" in failing["signature"]
+    assert failing["first_error_line"] > 0
+    assert "AssertionError" in failing["excerpt"]
+
+
+def test_parse_ci_log_strips_progress_and_groups():
+    out = parse_ci_log(GHA_NOISY_LOG)
+    for stage in out["failing"]:
+        assert "Receiving objects" not in stage["excerpt"]
+        assert "##[group]" not in stage["excerpt"]
+
+
+def test_parse_ci_log_plain_text():
+    text = "running tests\nTraceback (most recent call last):\n  File x\nFAIL\nok\n"
+    out = parse_ci_log(text)
+    assert out["stats"]["stages_failing"] == 1
+    assert out["failing"][0]["job"] is None
+    assert "Traceback" in out["failing"][0]["signature"]
+
+
+def test_parse_ci_log_excerpt_capped():
+    lines = ["job\tstep\t2024-05-20T12:00:00Z error number {}".format(i)
+             for i in range(50)]
+    out = parse_ci_log("\n".join(lines))
+    assert out["stats"]["stages_failing"] == 1
+    assert out["failing"][0]["excerpt"].count("\n") < 50
+
+
+def test_parse_ci_log_clean_returns_empty():
+    text = "Run pytest\ntest_a PASSED\ntest_b PASSED\nDone.\n"
+    out = parse_ci_log(text)
+    assert out["failing"] == []
+    assert out["stats"]["stages_failing"] == 0
+
+
+def test_summarize_runs_keeps_only_failed():
+    raw = [
+        {"databaseId": 1, "name": "ci", "conclusion": "success",
+         "headBranch": "main", "url": "u1", "createdAt": "2024-05-20T12:00:00Z"},
+        {"databaseId": 2, "name": "ci", "conclusion": "failure",
+         "headBranch": "feat/x", "url": "u2", "createdAt": "2024-05-20T13:00:00Z"},
+        {"databaseId": 3, "name": "ci", "conclusion": "cancelled",
+         "headBranch": "feat/y", "url": "u3", "createdAt": "2024-05-20T14:00:00Z"},
+        {"id": 4, "workflowName": "ci", "status": "in_progress",
+         "headBranch": "main", "url": "u4"},
+    ]
+    out = summarize_runs(raw)
+    ids = [r["id"] for r in out]
+    assert ids == [2, 3, 4]

--- a/tests/test_github_compact.py
+++ b/tests/test_github_compact.py
@@ -1,0 +1,95 @@
+"""Unit tests for agent.adapters.github_compact."""
+
+from __future__ import annotations
+
+from agent.adapters.github_compact import (
+    compact_issue,
+    compact_issue_list,
+    compact_pr,
+    compact_pr_checks,
+)
+
+
+def test_compact_issue_keeps_only_high_signal_fields():
+    raw = {
+        "number": 90,
+        "title": "Add adapters",
+        "state": "OPEN",
+        "url": "https://github.com/x/y/issues/90",
+        "author": {"login": "alice", "email": "alice@example.com", "bio": "..."},
+        "labels": [{"name": "perf"}, {"name": "tooling"}, {"color": "f00"}],
+        "comments": [{"id": 1}, {"id": 2}, {"id": 3}],
+        "body": "x" * 2000,
+        "updatedAt": "2024-05-20T12:00:00Z",
+        "extraNoise": "drop me",
+    }
+    out = compact_issue(raw)
+    assert out["number"] == 90
+    assert out["author"] == "alice"
+    assert out["labels"] == ["perf", "tooling"]
+    assert out["comments"] == 3
+    assert out["body"]["chars"] == 2000
+    assert len(out["body"]["preview"]) <= 240
+    assert out["body"]["handle"].startswith("body:")
+    assert "extraNoise" not in out
+
+
+def test_compact_issue_handles_missing_body_and_author():
+    out = compact_issue({"number": 1, "title": "t", "state": "OPEN"})
+    assert out["body"] == {"preview": "", "handle": None, "chars": 0}
+    assert out["author"] is None
+    assert out["labels"] == []
+    assert out["comments"] == 0
+
+
+def test_compact_issue_list_minifies():
+    raw = [
+        {"number": 1, "title": "a", "state": "OPEN", "labels": [{"name": "bug"}],
+         "url": "u1", "body": "x" * 10_000},
+        {"number": 2, "title": "b", "state": "CLOSED", "labels": [], "url": "u2"},
+    ]
+    out = compact_issue_list(raw)
+    assert out == [
+        {"number": 1, "title": "a", "state": "OPEN", "labels": ["bug"], "url": "u1"},
+        {"number": 2, "title": "b", "state": "CLOSED", "labels": [], "url": "u2"},
+    ]
+
+
+def test_compact_pr_preserves_diff_stats_and_drops_body():
+    raw = {
+        "number": 115,
+        "title": "feat: x",
+        "state": "OPEN",
+        "isDraft": True,
+        "url": "https://...",
+        "author": {"login": "bob"},
+        "baseRefName": "main",
+        "headRefName": "feat/x",
+        "additions": 120,
+        "deletions": 30,
+        "changedFiles": 4,
+        "mergeable": "MERGEABLE",
+        "body": "long " * 500,
+        "reviewDecision": "REVIEW_REQUIRED",
+    }
+    out = compact_pr(raw)
+    assert out["additions"] == 120 and out["deletions"] == 30
+    assert out["baseRef"] == "main" and out["headRef"] == "feat/x"
+    assert out["body"]["chars"] > 240
+    assert out["body"]["handle"]
+
+
+def test_compact_pr_checks_buckets_states():
+    raw = [
+        {"name": "lint", "state": "SUCCESS", "bucket": "pass"},
+        {"name": "unit", "state": "FAILURE", "bucket": "fail",
+         "link": "u", "workflow": "ci"},
+        {"name": "e2e", "state": "IN_PROGRESS", "bucket": "pending"},
+        {"name": "build", "conclusion": "TIMED_OUT"},
+    ]
+    out = compact_pr_checks(raw)
+    assert out["passing"] == 1
+    assert out["pending"] == 1
+    assert len(out["failing"]) == 2
+    names = {f["name"] for f in out["failing"]}
+    assert names == {"unit", "build"}


### PR DESCRIPTION
Tracks #90 — previously closed without commits, reopened to deliver real implementation.

## Scope
Add GitHub and CI token-optimized adapters

## Status
Scaffold only. Implementation plan in `.plans/issue-90-add-github-and-ci-token-optimized-adapters.md`. Will be expanded in follow-up commits until DoD is green.

Refs #90