### PR TITLE
track(#91): Add token savings telemetry and gain analytics

### DIFF
--- a/.plans/issue-91-add-token-savings-telemetry-and-gain-analytics.md
+++ b/.plans/issue-91-add-token-savings-telemetry-and-gain-analytics.md
@@ -1,0 +1,35 @@
+# Issue #91: Add token savings telemetry and gain analytics
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/91
+
+## Original description (excerpt)
+
+```
+## Goal
+Show how many tokens Hermes Turbo saves per command, session, project, and adapter.
+
+## Context
+RTK exposes `gain` analytics. Hermes Turbo should have its own measurable token economy story so optimization is visible and regressions are caught.
+
+## Acceptance criteria
+- Track estimated raw tokens, compressed tokens, saved tokens, and saving percentage per tool result.
+- Aggregate savings by command type, adapter, session, repo, and day.
+- Add CLI/report output for recent token savings.
+- Store metrics without capturing secrets or full prompt content.
+- Add docs explaining how to interpret token savings.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/agent/telemetry/__init__.py
+++ b/agent/telemetry/__init__.py
@@ -1,0 +1,10 @@
+"""Telemetry helpers for Hermes Turbo (token savings, gain analytics)."""
+
+from agent.telemetry.token_savings import (
+    TokenSavingRecord,
+    default_log_path,
+    iter_records,
+    record_token_saving,
+)
+
+__all__ = ["TokenSavingRecord", "default_log_path", "iter_records", "record_token_saving"]

--- a/agent/telemetry/gain_analytics.py
+++ b/agent/telemetry/gain_analytics.py
@@ -1,0 +1,108 @@
+"""Gain analytics CLI for token savings telemetry. See docs/perf/."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable, Optional
+
+from agent.telemetry.token_savings import default_log_path, iter_records
+
+
+def _int(rec: dict, key: str) -> int:
+    try:
+        return int(rec.get(key, 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _day(ts: str) -> str:
+    return ts[:10] if isinstance(ts, str) and len(ts) >= 10 else "unknown"
+
+
+def aggregate(records: Iterable[dict]) -> dict:
+    total_raw = total_comp = count = 0
+    by_tool: dict[str, dict[str, int]] = defaultdict(lambda: {"raw": 0, "saved": 0, "calls": 0})
+    by_day: dict[str, dict[str, int]] = defaultdict(lambda: {"raw": 0, "saved": 0, "calls": 0})
+    by_adapter: dict[str, int] = defaultdict(int)
+
+    for rec in records:
+        raw, comp = _int(rec, "raw_tokens"), _int(rec, "compressed_tokens")
+        saved = _int(rec, "saved_tokens") or max(0, raw - comp)
+        total_raw += raw
+        total_comp += comp
+        count += 1
+        for bucket, key in ((by_tool, str(rec.get("tool") or "unknown")),
+                            (by_day, _day(str(rec.get("ts") or "")))):
+            bucket[key]["raw"] += raw
+            bucket[key]["saved"] += saved
+            bucket[key]["calls"] += 1
+        by_adapter[str(rec.get("adapter") or "unknown")] += saved
+
+    saved_total = max(0, total_raw - total_comp)
+    pct = round(100.0 * saved_total / total_raw, 2) if total_raw else 0.0
+    return {
+        "records": count,
+        "total_raw_tokens": total_raw,
+        "total_compressed_tokens": total_comp,
+        "total_saved_tokens": saved_total,
+        "overall_savings_pct": pct,
+        "by_tool": dict(by_tool),
+        "by_day": dict(by_day),
+        "by_adapter": dict(by_adapter),
+    }
+
+
+def top_wasteful_tools(agg: dict, limit: int = 5) -> list[tuple[str, int, int]]:
+    """Return (tool, raw_tokens, saved_tokens) sorted by raw desc."""
+    items = [(t, v["raw"], v["saved"]) for t, v in agg.get("by_tool", {}).items()]
+    items.sort(key=lambda r: r[1], reverse=True)
+    return items[: max(0, limit)]
+
+
+def trend(agg: dict) -> list[tuple[str, int, int]]:
+    """Return (day, raw, saved) sorted by day ascending."""
+    items = [(d, v["raw"], v["saved"]) for d, v in agg.get("by_day", {}).items()]
+    items.sort(key=lambda r: r[0])
+    return items
+
+
+def _format_report(agg: dict, top_n: int) -> str:
+    head = [
+        "Hermes Turbo - Token Savings Report", "-" * 40,
+        f"Records:           {agg['records']}",
+        f"Raw tokens:        {agg['total_raw_tokens']}",
+        f"Compressed tokens: {agg['total_compressed_tokens']}",
+        f"Saved tokens:      {agg['total_saved_tokens']}",
+        f"Overall savings:   {agg['overall_savings_pct']}%", "",
+        f"Top {top_n} tools by raw tokens spent:",
+    ]
+    head += [f"  - {t:<24} raw={r:>8} saved={s:>8}" for t, r, s in top_wasteful_tools(agg, top_n)]
+    head += ["", "Daily trend:"]
+    head += [f"  {d}  raw={r:>8}  saved={s:>8}" for d, r, s in trend(agg)]
+    return "\n".join(head)
+
+
+def run(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="hermes-token-savings",
+        description="Aggregate Hermes Turbo token-savings telemetry.",
+    )
+    parser.add_argument("--log", type=Path, default=None, help="JSONL log path.")
+    parser.add_argument("--top", type=int, default=5, help="How many tools to list.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON.")
+    args = parser.parse_args(argv)
+    agg = aggregate(iter_records(args.log or default_log_path()))
+    if args.json:
+        json.dump(agg, sys.stdout, ensure_ascii=False, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(_format_report(agg, args.top) + "\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(run())

--- a/agent/telemetry/token_savings.py
+++ b/agent/telemetry/token_savings.py
@@ -1,0 +1,98 @@
+"""Token savings telemetry (JSONL, no secrets). See docs/perf/."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, Optional
+
+_ENV = "HERMES_TOKEN_SAVINGS_LOG"
+_REL = Path(".hermes") / "telemetry" / "token_savings.jsonl"
+
+
+def default_log_path() -> Path:
+    """Return the JSONL log path (env override or ``~/.hermes/...``)."""
+    override = os.environ.get(_ENV)
+    return Path(override).expanduser() if override else Path.home() / _REL
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass(frozen=True)
+class TokenSavingRecord:
+    """A single token-savings event."""
+
+    raw_tokens: int
+    compressed_tokens: int
+    tool: str = "unknown"
+    command: str = "unknown"
+    adapter: str = "unknown"
+    session: str = "unknown"
+    repo: str = "unknown"
+    ts: str = field(default_factory=_utc_now)
+    savings_pct: float = 0.0
+
+    @property
+    def saved_tokens(self) -> int:
+        return max(0, self.raw_tokens - self.compressed_tokens)
+
+    def to_json(self) -> str:
+        payload = asdict(self)
+        payload["saved_tokens"] = self.saved_tokens
+        return json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+
+
+def _pct(raw: int, comp: int) -> float:
+    if raw <= 0:
+        return 0.0
+    return round(100.0 * max(0, raw - comp) / raw, 2)
+
+
+def record_token_saving(
+    raw_tokens: int,
+    compressed_tokens: int,
+    *,
+    tool: str = "unknown",
+    command: str = "unknown",
+    adapter: str = "unknown",
+    session: str = "unknown",
+    repo: str = "unknown",
+    log_path: Optional[Path] = None,
+) -> TokenSavingRecord:
+    """Append a savings entry. Silent on disk errors."""
+    raw = max(0, int(raw_tokens))
+    comp = min(max(0, int(compressed_tokens)), raw)
+    record = TokenSavingRecord(
+        raw_tokens=raw, compressed_tokens=comp,
+        tool=tool, command=command, adapter=adapter, session=session, repo=repo,
+        savings_pct=_pct(raw, comp),
+    )
+    path = Path(log_path) if log_path else default_log_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(record.to_json() + "\n")
+    except OSError:
+        pass  # Telemetry must never break the caller.
+    return record
+
+
+def iter_records(log_path: Optional[Path] = None) -> Iterator[dict]:
+    """Yield each JSON object from the savings log. Skips malformed lines."""
+    path = Path(log_path) if log_path else default_log_path()
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue

--- a/docs/perf/token-savings-analytics.md
+++ b/docs/perf/token-savings-analytics.md
@@ -1,0 +1,49 @@
+# Token Savings Telemetry & Gain Analytics
+
+Hermes Turbo records how many tokens the compression pipeline saves per tool
+result and aggregates them through a small CLI.
+
+## Storage
+
+Default path `~/.hermes/telemetry/token_savings.jsonl`, override via
+`HERMES_TOKEN_SAVINGS_LOG`. Append-only JSONL; the recorder swallows OS
+errors so telemetry never breaks the agent loop.
+
+## Schema (one object per line)
+
+`ts` (ISO-8601 UTC, e.g. `2026-05-21T12:34:56Z`), `tool`, `command`,
+`adapter`, `session`, `repo`, `raw_tokens`, `compressed_tokens`,
+`saved_tokens` (`max(0, raw - compressed)`), `savings_pct`
+(`100 * saved / raw`, 2 decimals). No prompt content, no secrets.
+
+## Recording
+
+```python
+from agent.telemetry import record_token_saving
+
+record_token_saving(
+    raw_tokens=1200, compressed_tokens=380,
+    tool="read_file", adapter="anthropic",
+    session="sess-syn-001", repo="hermes-turbo-agent",
+)
+```
+
+## Reporting
+
+```bash
+python -m agent.telemetry.gain_analytics --top 10
+python -m agent.telemetry.gain_analytics --log /tmp/savings.jsonl --json
+```
+
+Text mode shows totals, top tools by raw tokens spent, and a per-day trend.
+`--json` emits the same aggregation as one JSON document.
+
+## Reading the numbers
+
+- Overall savings under ~50% usually means many tool outputs are opaque
+  (binary blobs) and the compressor can't inspect them.
+- A tool dominating raw tokens is a candidate for tighter prompts.
+- A drop in the daily trend often signals a compression regression - bisect.
+
+Telemetry is local-only; delete the file or point the env var at `/dev/null`
+to disable.

--- a/tests/agent/telemetry/test_gain_analytics.py
+++ b/tests/agent/telemetry/test_gain_analytics.py
@@ -1,0 +1,69 @@
+"""Tests for ``agent.telemetry.gain_analytics``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent.telemetry import gain_analytics
+
+
+SAMPLE = [
+    {"raw_tokens": 1000, "compressed_tokens": 200, "saved_tokens": 800,
+     "tool": "read_file", "adapter": "anthropic", "ts": "2026-05-20T10:00:00Z"},
+    {"raw_tokens": 500, "compressed_tokens": 100, "saved_tokens": 400,
+     "tool": "grep", "adapter": "anthropic", "ts": "2026-05-20T11:00:00Z"},
+    {"raw_tokens": 2000, "compressed_tokens": 800, "saved_tokens": 1200,
+     "tool": "read_file", "adapter": "gemini", "ts": "2026-05-21T09:00:00Z"},
+    {"raw_tokens": 100, "compressed_tokens": 90, "saved_tokens": 10,
+     "tool": "bash", "adapter": "gemini", "ts": "2026-05-21T12:00:00Z"},
+]
+
+
+def test_aggregate_totals() -> None:
+    agg = gain_analytics.aggregate(SAMPLE)
+    assert agg["records"] == 4
+    assert agg["total_raw_tokens"] == 3600
+    assert agg["total_saved_tokens"] == 2410
+    assert agg["overall_savings_pct"] == round(100 * 2410 / 3600, 2)
+
+
+def test_top_wasteful_tools_and_limit() -> None:
+    agg = gain_analytics.aggregate(SAMPLE)
+    top = gain_analytics.top_wasteful_tools(agg, limit=2)
+    assert top[0] == ("read_file", 3000, 2000)
+    assert top[1][0] == "grep"
+    assert gain_analytics.top_wasteful_tools(agg, limit=0) == []
+
+
+def test_trend_sorted_by_day() -> None:
+    days = gain_analytics.trend(gain_analytics.aggregate(SAMPLE))
+    assert [d for d, _, _ in days] == ["2026-05-20", "2026-05-21"]
+    assert days[0][1] == 1500 and days[1][1] == 2100
+
+
+def test_aggregate_handles_dirty_records() -> None:
+    agg = gain_analytics.aggregate([
+        {"raw_tokens": "bad", "compressed_tokens": 10, "ts": None},
+        {"raw_tokens": 100, "compressed_tokens": 25},
+    ])
+    assert agg["records"] == 2 and agg["total_raw_tokens"] == 100
+
+
+def test_run_text_and_json(tmp_path: Path, capsys) -> None:
+    log = tmp_path / "s.jsonl"
+    with log.open("w", encoding="utf-8") as fh:
+        for rec in SAMPLE:
+            fh.write(json.dumps(rec) + "\n")
+    assert gain_analytics.run(["--log", str(log), "--top", "2"]) == 0
+    txt = capsys.readouterr().out
+    assert "Token Savings Report" in txt and "read_file" in txt and "2026-05-20" in txt
+    assert gain_analytics.run(["--log", str(log), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["total_raw_tokens"] == 3600 and "by_tool" in payload
+
+
+def test_run_missing_log_is_empty(tmp_path: Path, capsys) -> None:
+    assert gain_analytics.run(["--log", str(tmp_path / "absent.jsonl"), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["records"] == 0 and payload["total_saved_tokens"] == 0

--- a/tests/agent/telemetry/test_token_savings.py
+++ b/tests/agent/telemetry/test_token_savings.py
@@ -1,0 +1,74 @@
+"""Tests for ``agent.telemetry.token_savings``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent.telemetry.token_savings import (
+    TokenSavingRecord,
+    default_log_path,
+    iter_records,
+    record_token_saving,
+)
+
+
+def test_record_token_saving_writes_jsonl(tmp_path: Path) -> None:
+    log = tmp_path / "savings.jsonl"
+    record = record_token_saving(
+        1000, 250, tool="read_file", adapter="anthropic", log_path=log,
+    )
+    assert (record.saved_tokens, record.savings_pct) == (750, 75.0)
+    payload = json.loads(log.read_text(encoding="utf-8").splitlines()[0])
+    assert payload["raw_tokens"] == 1000
+    assert payload["saved_tokens"] == 750
+    assert payload["tool"] == "read_file"
+
+
+def test_record_clamps_compressed_above_raw(tmp_path: Path) -> None:
+    record = record_token_saving(100, 500, log_path=tmp_path / "s.jsonl")
+    assert record.compressed_tokens == 100
+    assert record.savings_pct == 0.0
+
+
+def test_record_zero_raw_does_not_divide(tmp_path: Path) -> None:
+    record = record_token_saving(0, 0, log_path=tmp_path / "s.jsonl")
+    assert record.savings_pct == 0.0
+
+
+def test_iter_records_skips_blank_and_malformed(tmp_path: Path) -> None:
+    log = tmp_path / "savings.jsonl"
+    log.write_text(
+        '{"raw_tokens":10,"compressed_tokens":5}\n\nnot-json\n'
+        '{"raw_tokens":20,"compressed_tokens":4}\n',
+        encoding="utf-8",
+    )
+    records = list(iter_records(log))
+    assert len(records) == 2 and records[1]["compressed_tokens"] == 4
+
+
+def test_iter_records_missing_file_yields_empty(tmp_path: Path) -> None:
+    assert list(iter_records(tmp_path / "missing.jsonl")) == []
+
+
+def test_default_log_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    override = tmp_path / "custom.jsonl"
+    monkeypatch.setenv("HERMES_TOKEN_SAVINGS_LOG", str(override))
+    assert default_log_path() == override
+    monkeypatch.delenv("HERMES_TOKEN_SAVINGS_LOG")
+    assert default_log_path().name == "token_savings.jsonl"
+
+
+def test_token_saving_record_to_json_includes_saved() -> None:
+    record = TokenSavingRecord(raw_tokens=200, compressed_tokens=50, ts="2026-05-21T12:34:56Z")
+    payload = json.loads(record.to_json())
+    assert payload["saved_tokens"] == 150
+
+
+def test_record_handles_unwritable_path(tmp_path: Path) -> None:
+    blocker = tmp_path / "blocker"
+    blocker.write_text("x", encoding="utf-8")
+    record = record_token_saving(10, 1, log_path=blocker / "nested" / "log.jsonl")
+    assert record.saved_tokens == 9  # never raises


### PR DESCRIPTION
Tracks #91 — previously closed without commits, reopened to deliver real implementation.

## Scope
Add token savings telemetry and gain analytics

## Status
Scaffold only. Implementation plan in `.plans/issue-91-add-token-savings-telemetry-and-gain-analytics.md`. Will be expanded in follow-up commits until DoD is green.

Refs #91