### PR TITLE
track(#92): Implement context working set with expand-on-demand retrieval

### DIFF
--- a/.plans/issue-92-implement-context-working-set-with-expand-on-demand-retrieva.md
+++ b/.plans/issue-92-implement-context-working-set-with-expand-on-demand-retrieva.md
@@ -1,0 +1,35 @@
+# Issue #92: Implement context working set with expand-on-demand retrieval
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/92
+
+## Original description (excerpt)
+
+```
+## Goal
+Avoid loading whole repositories, files, logs, and histories into context when the agent only needs a small working set.
+
+## Context
+Token economy is not only command-output compression. Hermes Turbo should maintain a compact working set of relevant files, symbols, diffs, tests, and issue facts, then expand only when needed.
+
+## Acceptance criteria
+- Add a context working-set model for current task facts, files, symbols, diffs, commands, and evidence handles.
+- Prefer snippets, signatures, and summaries over full files by default.
+- Add explicit expansion APIs for full file, wider snippet, full diff, full log, or raw evidence.
+- Integrate with existing skill/project indexing where available.
+- Include tests that large inputs stay under configured token budgets.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/agent/context/__init__.py
+++ b/agent/context/__init__.py
@@ -1,0 +1,13 @@
+"""Context working set with expand-on-demand retrieval (Issue #92)."""
+
+from .working_set import ColdRef, HotEntry, WorkingSet, WorkingSetBudgetError
+from .retrieval import RelevanceScorer, ScoredHandle
+
+__all__ = [
+    "ColdRef",
+    "HotEntry",
+    "WorkingSet",
+    "WorkingSetBudgetError",
+    "RelevanceScorer",
+    "ScoredHandle",
+]

--- a/agent/context/retrieval.py
+++ b/agent/context/retrieval.py
@@ -1,0 +1,69 @@
+"""Stdlib TF-IDF relevance scorer for picking cold refs to expand.
+
+Pure ``math`` + ``collections.Counter`` -- no numpy / sklearn. Ranks a
+small corpus of handles against a query so the agent can decide which
+cold ref to ``expand``.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
+
+
+def _tokenize(text: str) -> list[str]:
+    return [t.lower() for t in _TOKEN_RE.findall(text or "")]
+
+
+@dataclass(frozen=True)
+class ScoredHandle:
+    key: str
+    score: float
+
+
+class RelevanceScorer:
+    """TF-IDF cosine scorer over a small corpus of handle summaries."""
+
+    def __init__(self, corpus: Mapping[str, str]) -> None:
+        self._docs: dict[str, Counter[str]] = {
+            k: Counter(_tokenize(text)) for k, text in corpus.items()
+        }
+        n = max(1, len(self._docs))
+        df: Counter[str] = Counter()
+        for d in self._docs.values():
+            df.update(d.keys())
+        self._idf = {t: math.log((1 + n) / (1 + c)) + 1.0 for t, c in df.items()}
+        self._norms = {
+            k: math.sqrt(sum((f * self._idf.get(t, 0.0)) ** 2
+                             for t, f in tf.items())) or 1.0
+            for k, tf in self._docs.items()
+        }
+
+    def score(self, query: str, *, top_k: int | None = None) -> list[ScoredHandle]:
+        q_tf = Counter(_tokenize(query))
+        if not q_tf:
+            return []
+        q_vec = {t: f * self._idf.get(t, 0.0) for t, f in q_tf.items()}
+        q_norm = math.sqrt(sum(v * v for v in q_vec.values())) or 1.0
+        ranked: list[ScoredHandle] = []
+        for key, tf in self._docs.items():
+            dot = sum(qw * tf[t] * self._idf.get(t, 0.0)
+                      for t, qw in q_vec.items() if t in tf)
+            if dot:
+                ranked.append(ScoredHandle(key, dot / (q_norm * self._norms[key])))
+        ranked.sort(key=lambda h: h.score, reverse=True)
+        return ranked[:top_k] if top_k is not None else ranked
+
+    def best(self, query: str) -> ScoredHandle | None:
+        r = self.score(query, top_k=1)
+        return r[0] if r else None
+
+    @classmethod
+    def from_pairs(cls, pairs: Sequence[tuple[str, str]]) -> "RelevanceScorer":
+        return cls(dict(pairs))

--- a/agent/context/working_set.py
+++ b/agent/context/working_set.py
@@ -1,0 +1,156 @@
+"""Hot working set + cold ref store with LRU eviction and expand-on-demand.
+
+Hermes keeps a small hot set of facts (snippets, signatures, summaries) and
+parks large blobs (full files, diffs, logs) as cold refs. ``expand(handle)``
+promotes a cold ref into hot on demand; LRU eviction (skipping pinned
+entries) keeps the budget. Pure stdlib so it runs in every adapter.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Callable, Iterator, Optional
+
+
+class WorkingSetBudgetError(RuntimeError):
+    """Raised when an entry cannot fit the configured token budget."""
+
+
+def _tokens(text: str) -> int:
+    return max(1, (len(text) + 3) // 4)
+
+
+@dataclass
+class HotEntry:
+    key: str
+    kind: str  # fact | snippet | signature | summary | diff | log | evidence
+    content: str
+    tokens: int
+    pinned: bool = False
+    source: Optional[str] = None
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass
+class ColdRef:
+    """Handle to a large blob; ``loader`` is invoked lazily by ``expand``."""
+
+    key: str
+    kind: str
+    summary: str
+    loader: Callable[[], str]
+    source: Optional[str] = None
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+
+class WorkingSet:
+    """LRU-bounded hot set + cold ref side-store."""
+
+    def __init__(self, token_budget: int = 4000,
+                 token_estimator: Callable[[str], int] = _tokens) -> None:
+        if token_budget <= 0:
+            raise ValueError("token_budget must be positive")
+        self._budget = token_budget
+        self._estimate = token_estimator
+        self._hot: "OrderedDict[str, HotEntry]" = OrderedDict()
+        self._cold: dict[str, ColdRef] = {}
+        self._used = 0
+
+    @property
+    def token_budget(self) -> int:
+        return self._budget
+
+    @property
+    def tokens_used(self) -> int:
+        return self._used
+
+    def __len__(self) -> int:
+        return len(self._hot)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._hot
+
+    def __iter__(self) -> Iterator[HotEntry]:
+        return iter(self._hot.values())
+
+    def add(self, key: str, content: str, *, kind: str = "fact", pinned: bool = False,
+            source: Optional[str] = None, tags: tuple[str, ...] = ()) -> HotEntry:
+        tokens = self._estimate(content)
+        if tokens > self._budget:
+            raise WorkingSetBudgetError(
+                f"entry {key!r} needs {tokens} > budget {self._budget}")
+        if key in self._hot:
+            self._used -= self._hot[key].tokens
+            del self._hot[key]
+        self._make_room(tokens)
+        entry = HotEntry(key=key, kind=kind, content=content, tokens=tokens,
+                         pinned=pinned, source=source, tags=tags)
+        self._hot[key] = entry
+        self._used += tokens
+        return entry
+
+    def get(self, key: str) -> Optional[HotEntry]:
+        entry = self._hot.get(key)
+        if entry is not None:
+            self._hot.move_to_end(key)
+        return entry
+
+    def touch(self, key: str) -> None:
+        if key in self._hot:
+            self._hot.move_to_end(key)
+
+    def pin(self, key: str) -> None:
+        if key in self._hot:
+            self._hot[key].pinned = True
+
+    def unpin(self, key: str) -> None:
+        if key in self._hot:
+            self._hot[key].pinned = False
+
+    def remove(self, key: str) -> bool:
+        entry = self._hot.pop(key, None)
+        if entry is None:
+            return False
+        self._used -= entry.tokens
+        return True
+
+    def hot_keys(self) -> list[str]:
+        return list(self._hot.keys())
+
+    def cold_keys(self) -> list[str]:
+        return list(self._cold.keys())
+
+    def register_cold(self, ref: ColdRef) -> None:
+        """Register a cold handle and stash its summary in hot."""
+        self._cold[ref.key] = ref
+        self.add(ref.key, ref.summary, kind="summary",
+                 source=ref.source, tags=ref.tags)
+
+    def expand(self, key: str) -> HotEntry:
+        """Materialise a cold ref into the hot set on demand."""
+        ref = self._cold.get(key)
+        if ref is None:
+            raise KeyError(f"no cold ref for {key!r}")
+        return self.add(key, ref.loader(), kind=ref.kind,
+                        source=ref.source, tags=ref.tags)
+
+    def collapse(self, key: str) -> None:
+        """Revert an expanded entry to its summary form."""
+        ref = self._cold.get(key)
+        if ref is None:
+            raise KeyError(f"no cold ref for {key!r}")
+        self.add(key, ref.summary, kind="summary",
+                 source=ref.source, tags=ref.tags)
+
+    def _make_room(self, needed: int) -> None:
+        for key in list(self._hot.keys()):
+            if self._used + needed <= self._budget:
+                return
+            if self._hot[key].pinned:
+                continue
+            self._used -= self._hot[key].tokens
+            del self._hot[key]
+        if self._used + needed > self._budget:
+            raise WorkingSetBudgetError(
+                "cannot fit entry: all remaining entries are pinned")

--- a/docs/context/working-set.md
+++ b/docs/context/working-set.md
@@ -1,0 +1,52 @@
+# Context working set with expand-on-demand retrieval
+
+Tracks Issue [#92](https://github.com/wesleysimplicio/hermes-turbo-agent/issues/92).
+Module: `agent/context/`.
+
+## Shape
+
+`WorkingSet` keeps a small **hot** LRU of `HotEntry` objects within a
+token budget, plus a side-store of `ColdRef` handles whose payload loads
+lazily. `HotEntry.kind` is `fact | snippet | signature | summary | diff
+| log | evidence`. Registering a cold ref also writes its `summary` into
+hot so the model knows the handle exists.
+
+## API
+
+```python
+from agent.context import WorkingSet, ColdRef, RelevanceScorer
+
+ws = WorkingSet(token_budget=4000)
+ws.add("task", "fix retrieval bug", kind="fact", pinned=True)
+
+ws.register_cold(ColdRef(
+    key="agent/run_agent.py",
+    kind="snippet",
+    summary="run_agent.py: AIAgent orchestrator",
+    loader=lambda: open("agent/run_agent.py").read(),
+))
+
+scorer = RelevanceScorer({k: ws.get(k).content for k in ws.cold_keys()})
+pick = scorer.best("where is AIAgent constructed")
+if pick:
+    full = ws.expand(pick.key)   # promotes cold -> hot
+    ws.collapse(pick.key)        # back to summary when done
+```
+
+## Budget + eviction
+
+LRU over the hot `OrderedDict`. `pin(key)` makes an entry non-evictable.
+If no unpinned entry can be evicted to fit a new one, `add` / `expand`
+raises `WorkingSetBudgetError`.
+
+## Retrieval
+
+`RelevanceScorer` is a stdlib TF-IDF cosine ranker (no numpy / sklearn);
+build once per task, call `best` or `score(top_k=N)`.
+
+## Acceptance for Issue #92
+
+Working-set model for facts/files/symbols/diffs/commands/evidence;
+snippets+summaries by default with explicit `expand`/`collapse` API;
+token-budget LRU with pin/unpin; test asserts large inputs stay under
+budget; pure stdlib for every adapter.

--- a/tests/agent/test_context_working_set.py
+++ b/tests/agent/test_context_working_set.py
@@ -1,0 +1,110 @@
+"""Tests for ``agent.context`` working set + retrieval (Issue #92)."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.context import ColdRef, RelevanceScorer, WorkingSet, WorkingSetBudgetError
+
+
+def test_add_get_and_replace() -> None:
+    ws = WorkingSet(token_budget=200)
+    ws.add("task", "fix retrieval bug", kind="fact")
+    e = ws.get("task")
+    assert e is not None and e.content == "fix retrieval bug" and e.kind == "fact"
+    ws.add("task", "y" * 80)
+    assert len(ws) == 1
+
+
+def test_lru_eviction_and_pin() -> None:
+    ws = WorkingSet(token_budget=30)
+    ws.add("a", "alpha" * 8)
+    ws.add("b", "bravo" * 8)
+    ws.touch("a")  # b is now LRU
+    ws.add("c", "charlie" * 8)
+    keys = ws.hot_keys()
+    assert "b" not in keys and "a" in keys and "c" in keys
+    ws.add("pinned", "p" * 16, pinned=True)
+    ws.add("x1", "x" * 16)
+    ws.add("x2", "z" * 16)
+    assert "pinned" in ws
+
+
+def test_budget_errors() -> None:
+    ws = WorkingSet(token_budget=5)
+    with pytest.raises(WorkingSetBudgetError):
+        ws.add("too_big", "x" * 4000)
+    ws2 = WorkingSet(token_budget=20)
+    ws2.add("p1", "p" * 40, pinned=True)
+    ws2.add("p2", "q" * 40, pinned=True)
+    with pytest.raises(WorkingSetBudgetError):
+        ws2.add("new", "n" * 40)
+    with pytest.raises(ValueError):
+        WorkingSet(token_budget=0)
+
+
+def test_cold_ref_lazy_load_and_expand_collapse() -> None:
+    loads = {"n": 0}
+
+    def loader() -> str:
+        loads["n"] += 1
+        return "the full doc body for Foo class"
+
+    ws = WorkingSet(token_budget=2000)
+    ws.register_cold(ColdRef("doc", "snippet", "doc: defines Foo", loader,
+                             source="repo/doc", tags=("py",)))
+    summary = ws.get("doc")
+    assert summary is not None and summary.kind == "summary" and loads["n"] == 0
+    promoted = ws.expand("doc")
+    assert "Foo class" in promoted.content and promoted.kind == "snippet"
+    ws.collapse("doc")
+    assert ws.get("doc").content == "doc: defines Foo"
+    with pytest.raises(KeyError):
+        ws.expand("ghost")
+
+
+def test_large_inputs_stay_under_budget() -> None:
+    """AC: large inputs cannot blow the configured token budget."""
+    ws = WorkingSet(token_budget=500)
+    for i in range(50):
+        ws.register_cold(ColdRef(f"f{i}", "snippet", f"f{i} line",
+                                 loader=lambda i=i: "PAYLOAD " * 5000))
+    assert ws.tokens_used <= ws.token_budget
+    with pytest.raises(WorkingSetBudgetError):
+        ws.expand("f0")
+    assert ws.tokens_used <= ws.token_budget
+
+
+def test_remove_and_unpin() -> None:
+    ws = WorkingSet(token_budget=200)
+    ws.add("a", "x" * 80, pinned=True)
+    ws.unpin("a")
+    assert ws.remove("a") and ws.tokens_used == 0 and not ws.remove("a")
+
+
+def test_relevance_scorer() -> None:
+    scorer = RelevanceScorer({
+        "auth": "login session token oauth jwt",
+        "billing": "invoice stripe payment subscription",
+        "ws": "context working set retrieval expand cold hot",
+    })
+    assert scorer.score("expand working set retrieval")[0].key == "ws"
+    assert scorer.score("") == []
+    assert scorer.best("") is None
+    assert scorer.score("zzz nothing matches") == []
+    best = RelevanceScorer.from_pairs([("a", "http client"), ("b", "db driver")]).best("http tuning")
+    assert best is not None and best.key == "a" and best.score > 0
+
+
+def test_end_to_end_pick_and_expand() -> None:
+    summaries = {
+        "auth.py": "module auth login session token",
+        "ctx.py": "module context working set retrieval expand cold hot",
+    }
+    payloads = {"auth.py": "auth code", "ctx.py": "ctx code with WorkingSet"}
+    ws = WorkingSet(token_budget=4000)
+    for k, s in summaries.items():
+        ws.register_cold(ColdRef(k, "snippet", s, loader=lambda k=k: payloads[k]))
+    pick = RelevanceScorer(summaries).best("how does the working set expand cold refs")
+    assert pick is not None and pick.key == "ctx.py"
+    assert "WorkingSet" in ws.expand(pick.key).content


### PR DESCRIPTION
Tracks #92 — previously closed without commits, reopened to deliver real implementation.

## Scope
Implement context working set with expand-on-demand retrieval

## Status
Scaffold only. Implementation plan in `.plans/issue-92-implement-context-working-set-with-expand-on-demand-retrieva.md`. Will be expanded in follow-up commits until DoD is green.

Refs #92