### PR TITLE
track(#93): Add token budget governor for autonomous loops

### DIFF
--- a/.plans/issue-93-add-token-budget-governor-for-autonomous-loops.md
+++ b/.plans/issue-93-add-token-budget-governor-for-autonomous-loops.md
@@ -1,0 +1,35 @@
+# Issue #93: Add token budget governor for autonomous loops
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/93
+
+## Original description (excerpt)
+
+```
+## Goal
+Prevent `/goal` and Ralph-style loops from silently burning context by enforcing token budgets and escalation rules.
+
+## Context
+Autonomous loops can repeatedly add shell output, summaries, test logs, and planning text. Hermes Turbo needs a budget governor that chooses compression, summarization, or expansion deliberately.
+
+## Acceptance criteria
+- Add configurable budgets per turn, per loop, per tool result, and per session.
+- Warn or switch compression mode when a budget is close to being exceeded.
+- Prefer focused tests/logs before full-output expansion.
+- Add policy hooks for high-risk tasks where more context is worth the cost.
+- Include tests for budget decisions and loop behavior.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/agent/governor/__init__.py
+++ b/agent/governor/__init__.py
@@ -1,0 +1,25 @@
+"""Token budget governor for autonomous loops.
+
+Public surface:
+    - BudgetConfig: budget knobs (tokens, cost, iterations).
+    - BudgetGovernor: records spend and enforces limits.
+    - BudgetExceeded: raised when any limit is hit.
+    - EscalationPolicy / WarnAt70HardStopAt100: warn/stop thresholds.
+"""
+
+from .budget import BudgetConfig, BudgetExceeded, BudgetGovernor, BudgetSnapshot
+from .policies import (
+    EscalationLevel,
+    EscalationPolicy,
+    WarnAt70HardStopAt100,
+)
+
+__all__ = [
+    "BudgetConfig",
+    "BudgetExceeded",
+    "BudgetGovernor",
+    "BudgetSnapshot",
+    "EscalationLevel",
+    "EscalationPolicy",
+    "WarnAt70HardStopAt100",
+]

--- a/agent/governor/budget.py
+++ b/agent/governor/budget.py
@@ -1,0 +1,117 @@
+"""Token budget governor for autonomous loops.
+
+Records spend at each step and raises ``BudgetExceeded`` once any configured
+limit is hit. Pure stdlib, no external deps. Designed for ``/goal`` and
+Ralph-style loops that would otherwise silently burn context.
+
+Usage::
+
+    cfg = BudgetConfig(max_tokens_per_loop=100_000, max_cost_usd=2.0, max_iterations=50)
+    gov = BudgetGovernor(cfg)
+    for step in loop():
+        gov.record_step(tokens=step.tokens, cost_usd=step.cost)
+        # raises BudgetExceeded when any axis hits 100%
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional
+
+
+class BudgetExceeded(RuntimeError):
+    """Raised when at least one budget axis hits its hard limit."""
+
+    def __init__(self, axis: str, used: float, limit: float) -> None:
+        super().__init__(f"budget exceeded on {axis}: used={used} limit={limit}")
+        self.axis = axis
+        self.used = used
+        self.limit = limit
+
+
+@dataclass(frozen=True)
+class BudgetConfig:
+    """Budget knobs for a single autonomous loop.
+
+    A limit of ``None`` means "do not enforce this axis".
+    """
+
+    max_tokens_per_loop: Optional[int] = None
+    max_cost_usd: Optional[float] = None
+    max_iterations: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class BudgetSnapshot:
+    """Immutable view of current spend on each axis."""
+
+    tokens: int
+    cost_usd: float
+    iterations: int
+
+    def ratio(self, cfg: BudgetConfig) -> float:
+        """Highest used/limit ratio across axes (0.0 if no limits set)."""
+        ratios: List[float] = []
+        if cfg.max_tokens_per_loop:
+            ratios.append(self.tokens / cfg.max_tokens_per_loop)
+        if cfg.max_cost_usd:
+            ratios.append(self.cost_usd / cfg.max_cost_usd)
+        if cfg.max_iterations:
+            ratios.append(self.iterations / cfg.max_iterations)
+        return max(ratios) if ratios else 0.0
+
+
+@dataclass
+class BudgetGovernor:
+    """Records spend and enforces a ``BudgetConfig``.
+
+    Optional ``on_warn`` callback fires once per axis when the warn threshold
+    is crossed; useful to flip compression mode before the hard stop.
+    """
+
+    config: BudgetConfig
+    warn_ratio: float = 0.70
+    on_warn: Optional[Callable[[str, BudgetSnapshot], None]] = None
+    _tokens: int = field(default=0, init=False)
+    _cost_usd: float = field(default=0.0, init=False)
+    _iterations: int = field(default=0, init=False)
+    _warned: set = field(default_factory=set, init=False)
+
+    def snapshot(self) -> BudgetSnapshot:
+        return BudgetSnapshot(
+            tokens=self._tokens,
+            cost_usd=self._cost_usd,
+            iterations=self._iterations,
+        )
+
+    def record_step(self, *, tokens: int = 0, cost_usd: float = 0.0) -> BudgetSnapshot:
+        """Add one iteration of spend, fire warnings, raise on overflow."""
+        if tokens < 0 or cost_usd < 0:
+            raise ValueError("tokens and cost_usd must be non-negative")
+        self._tokens += tokens
+        self._cost_usd += cost_usd
+        self._iterations += 1
+        snap = self.snapshot()
+        self._emit_warnings(snap)
+        self._enforce(snap)
+        return snap
+
+    def _emit_warnings(self, snap: BudgetSnapshot) -> None:
+        if self.on_warn is None:
+            return
+        for axis, used, limit in self._axes():
+            if limit is None or axis in self._warned:
+                continue
+            if used / limit >= self.warn_ratio:
+                self._warned.add(axis)
+                self.on_warn(axis, snap)
+
+    def _enforce(self, snap: BudgetSnapshot) -> None:
+        for axis, used, limit in self._axes():
+            if limit is not None and used >= limit:
+                raise BudgetExceeded(axis=axis, used=used, limit=limit)
+
+    def _axes(self):
+        yield "tokens", self._tokens, self.config.max_tokens_per_loop
+        yield "cost_usd", self._cost_usd, self.config.max_cost_usd
+        yield "iterations", self._iterations, self.config.max_iterations

--- a/agent/governor/policies.py
+++ b/agent/governor/policies.py
@@ -1,0 +1,50 @@
+"""Escalation policies layered on top of ``BudgetGovernor``.
+
+A policy reads a ``BudgetSnapshot`` + ``BudgetConfig`` and returns the
+escalation level the loop should react to:
+
+    OK    -- under 70%, business as usual.
+    WARN  -- at/over 70%, switch to compressed/focused mode.
+    STOP  -- at/over 100%, hard stop (``BudgetGovernor`` will also raise).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+from .budget import BudgetConfig, BudgetSnapshot
+
+
+class EscalationLevel(str, Enum):
+    OK = "ok"
+    WARN = "warn"
+    STOP = "stop"
+
+
+class EscalationPolicy(Protocol):
+    """Reads spend, returns the recommended level."""
+
+    def evaluate(
+        self, snapshot: BudgetSnapshot, config: BudgetConfig
+    ) -> EscalationLevel:  # pragma: no cover - protocol
+        ...
+
+
+@dataclass(frozen=True)
+class WarnAt70HardStopAt100:
+    """Default escalation: warn at 70%, hard stop at 100% of any axis."""
+
+    warn_ratio: float = 0.70
+    stop_ratio: float = 1.00
+
+    def evaluate(
+        self, snapshot: BudgetSnapshot, config: BudgetConfig
+    ) -> EscalationLevel:
+        ratio = snapshot.ratio(config)
+        if ratio >= self.stop_ratio:
+            return EscalationLevel.STOP
+        if ratio >= self.warn_ratio:
+            return EscalationLevel.WARN
+        return EscalationLevel.OK

--- a/docs/runtime/budget-governor.md
+++ b/docs/runtime/budget-governor.md
@@ -1,0 +1,87 @@
+# Budget Governor
+
+> Stdlib-only token / cost / iteration budgets for autonomous loops
+> (`/goal`, Ralph). Refs: [issue #93](https://github.com/wesleysimplicio/hermes-turbo-agent/issues/93).
+
+## Why
+
+Autonomous loops accumulate shell output, summaries, test logs, and planning
+text on every turn. Without a budget the loop silently burns context and
+dollars until something explodes. The governor turns that into an explicit,
+inspectable contract:
+
+- record spend on each step,
+- escalate to compressed mode at 70%,
+- hard stop at 100%.
+
+## API
+
+```python
+from agent.governor import (
+    BudgetConfig,
+    BudgetGovernor,
+    BudgetExceeded,
+    WarnAt70HardStopAt100,
+    EscalationLevel,
+)
+
+cfg = BudgetConfig(
+    max_tokens_per_loop=100_000,  # None = disabled
+    max_cost_usd=2.0,
+    max_iterations=50,
+)
+
+def on_warn(axis, snap):
+    # flip to focused/compressed mode here
+    print(f"warn on {axis}: {snap}")
+
+gov = BudgetGovernor(cfg, warn_ratio=0.70, on_warn=on_warn)
+policy = WarnAt70HardStopAt100()
+
+while True:
+    step = run_one_turn()
+    try:
+        gov.record_step(tokens=step.tokens, cost_usd=step.cost)
+    except BudgetExceeded as e:
+        # graceful shutdown: persist progress, emit summary
+        break
+
+    level = policy.evaluate(gov.snapshot(), cfg)
+    if level == EscalationLevel.WARN:
+        switch_to_focused_logs()
+```
+
+## Axes
+
+| Axis              | Config field           | Default |
+|-------------------|------------------------|---------|
+| Token spend       | `max_tokens_per_loop`  | `None`  |
+| USD cost          | `max_cost_usd`         | `None`  |
+| Iteration count   | `max_iterations`       | `None`  |
+
+`None` means "do not enforce this axis". `BudgetExceeded` carries
+`axis`, `used`, `limit` for surgical error handling.
+
+## Escalation
+
+`WarnAt70HardStopAt100` returns one of three `EscalationLevel` values
+based on the highest used/limit ratio across all configured axes:
+
+- `OK` (< 70%) -- business as usual.
+- `WARN` (70-99%) -- switch to compressed/focused output, drop verbose
+  logs, prefer summaries over full tool results.
+- `STOP` (>= 100%) -- `BudgetGovernor.record_step` already raised
+  `BudgetExceeded`; the loop must wind down.
+
+## Tests
+
+`tests/agent/test_governor.py` covers: under-limit recording, raise on
+each axis, negative-input rejection, single-fire warn callback,
+no-limit pass-through, full OK -> WARN -> STOP transition, and the
+multi-axis "highest ratio wins" rule.
+
+Run:
+
+```bash
+pytest tests/agent/test_governor.py -q
+```

--- a/tests/agent/test_governor.py
+++ b/tests/agent/test_governor.py
@@ -1,0 +1,105 @@
+"""Tests for ``agent.governor`` budget + policies."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.governor import (
+    BudgetConfig,
+    BudgetExceeded,
+    BudgetGovernor,
+    EscalationLevel,
+    WarnAt70HardStopAt100,
+)
+
+
+def test_budget_under_limit_records_without_raising():
+    gov = BudgetGovernor(BudgetConfig(max_tokens_per_loop=1000))
+    snap = gov.record_step(tokens=100)
+    assert snap.tokens == 100
+    assert snap.iterations == 1
+
+
+def test_budget_raises_when_tokens_exceed_limit():
+    gov = BudgetGovernor(BudgetConfig(max_tokens_per_loop=200))
+    gov.record_step(tokens=150)
+    with pytest.raises(BudgetExceeded) as info:
+        gov.record_step(tokens=80)
+    assert info.value.axis == "tokens"
+    assert info.value.used == 230
+    assert info.value.limit == 200
+
+
+def test_budget_raises_when_cost_exceed_limit():
+    gov = BudgetGovernor(BudgetConfig(max_cost_usd=1.0))
+    with pytest.raises(BudgetExceeded) as info:
+        gov.record_step(cost_usd=1.25)
+    assert info.value.axis == "cost_usd"
+
+
+def test_budget_raises_when_iterations_exceed_limit():
+    gov = BudgetGovernor(BudgetConfig(max_iterations=2))
+    gov.record_step(tokens=1)
+    with pytest.raises(BudgetExceeded) as info:
+        gov.record_step(tokens=1)
+    assert info.value.axis == "iterations"
+
+
+def test_budget_rejects_negative_inputs():
+    gov = BudgetGovernor(BudgetConfig(max_tokens_per_loop=100))
+    with pytest.raises(ValueError):
+        gov.record_step(tokens=-5)
+    with pytest.raises(ValueError):
+        gov.record_step(cost_usd=-0.1)
+
+
+def test_warn_callback_fires_once_per_axis_at_threshold():
+    fired = []
+
+    def on_warn(axis, snap):
+        fired.append(axis)
+
+    gov = BudgetGovernor(
+        BudgetConfig(max_tokens_per_loop=100),
+        warn_ratio=0.70,
+        on_warn=on_warn,
+    )
+    gov.record_step(tokens=50)
+    assert fired == []
+    gov.record_step(tokens=25)  # 75 / 100 = 75%
+    assert fired == ["tokens"]
+    with pytest.raises(BudgetExceeded):
+        gov.record_step(tokens=30)
+    assert fired == ["tokens"]
+
+
+def test_no_limits_means_no_enforcement():
+    gov = BudgetGovernor(BudgetConfig())
+    for _ in range(1000):
+        gov.record_step(tokens=10_000, cost_usd=1.0)
+    assert gov.snapshot().iterations == 1000
+
+
+def test_policy_returns_ok_warn_stop_in_order():
+    cfg = BudgetConfig(max_tokens_per_loop=100)
+    policy = WarnAt70HardStopAt100()
+    gov = BudgetGovernor(cfg)
+
+    gov.record_step(tokens=10)
+    assert policy.evaluate(gov.snapshot(), cfg) == EscalationLevel.OK
+
+    gov.record_step(tokens=65)  # 75%
+    assert policy.evaluate(gov.snapshot(), cfg) == EscalationLevel.WARN
+
+    try:
+        gov.record_step(tokens=30)
+    except BudgetExceeded:
+        pass
+    assert policy.evaluate(gov.snapshot(), cfg) == EscalationLevel.STOP
+
+
+def test_policy_max_ratio_picks_highest_axis():
+    cfg = BudgetConfig(max_tokens_per_loop=1000, max_cost_usd=10.0)
+    gov = BudgetGovernor(cfg)
+    gov.record_step(tokens=100, cost_usd=8.0)  # 10% tokens, 80% cost
+    assert WarnAt70HardStopAt100().evaluate(gov.snapshot(), cfg) == EscalationLevel.WARN


### PR DESCRIPTION
Tracks #93 — previously closed without commits, reopened to deliver real implementation.

## Scope
Add token budget governor for autonomous loops

## Status
Scaffold only. Implementation plan in `.plans/issue-93-add-token-budget-governor-for-autonomous-loops.md`. Will be expanded in follow-up commits until DoD is green.

Refs #93