### PR TITLE
track(#94): Add RTK compatibility and external token-saver bridge

### DIFF
--- a/.plans/issue-94-add-rtk-compatibility-and-external-token-saver-bridge.md
+++ b/.plans/issue-94-add-rtk-compatibility-and-external-token-saver-bridge.md
@@ -1,0 +1,35 @@
+# Issue #94: Add RTK compatibility and external token-saver bridge
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/94
+
+## Original description (excerpt)
+
+```
+## Goal
+Let users who already installed RTK or similar tools benefit from them while Hermes Turbo keeps a native fallback.
+
+## Context
+RTK supports Codex/Claude-style workflows by rewriting shell commands into compact proxy calls. Hermes Turbo should detect and optionally use compatible external token savers without making them mandatory dependencies.
+
+## Acceptance criteria
+- Detect whether `rtk` is installed and available.
+- Add config to choose `native`, `rtk`, or `auto` token-saver backend.
+- Keep native summarization as the default/fallback.
+- Document setup tradeoffs and safety considerations.
+- Add tests for backend selection and fallback behavior.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/agent/adapters/__init__.py
+++ b/agent/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""External tool adapters (rtk_bridge, ...)."""
+
+from agent.adapters import rtk_bridge
+
+__all__ = ["rtk_bridge"]

--- a/agent/adapters/rtk_bridge.py
+++ b/agent/adapters/rtk_bridge.py
@@ -1,0 +1,103 @@
+"""RTK compatibility bridge.
+
+Optional bridge for the RTK token-saver CLI (https://github.com/rtk-ai/rtk).
+If `rtk` is on PATH, shell commands can be routed through `rtk <cmd>`;
+otherwise the plain command is returned unchanged.
+
+Backends:
+- ``native``: never use rtk, return argv as-is.
+- ``rtk``: always wrap with rtk; raise if rtk is missing.
+- ``auto`` (default): wrap with rtk when detected and the command is in the
+  compatibility allow-list, otherwise fall through.
+
+Backend is selected via the ``HERMES_TOKEN_SAVER`` env var.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Iterable, List, Sequence
+
+BACKEND_NATIVE = "native"
+BACKEND_RTK = "rtk"
+BACKEND_AUTO = "auto"
+VALID_BACKENDS = frozenset({BACKEND_NATIVE, BACKEND_RTK, BACKEND_AUTO})
+
+ENV_BACKEND = "HERMES_TOKEN_SAVER"
+
+# Commands RTK accepts as a direct prefix; anything else falls through.
+RTK_COMPATIBLE_COMMANDS = frozenset(
+    {"read", "grep", "find", "git", "npx", "ls", "cat", "head", "tail"}
+)
+
+
+class RtkNotInstalledError(RuntimeError):
+    """Raised when backend=rtk is requested but the binary is missing."""
+
+
+def is_rtk_available() -> bool:
+    return shutil.which("rtk") is not None
+
+
+def resolve_backend(requested: str | None = None) -> str:
+    candidate = (requested or os.environ.get(ENV_BACKEND) or BACKEND_AUTO).strip().lower()
+    return candidate if candidate in VALID_BACKENDS else BACKEND_AUTO
+
+
+def wrap_command(argv: Sequence[str], backend: str | None = None) -> List[str]:
+    """Transform ``argv`` according to the active backend. Never executes."""
+    if not argv:
+        return []
+    argv_list = [str(a) for a in argv]
+    mode = resolve_backend(backend)
+
+    if mode == BACKEND_NATIVE:
+        return argv_list
+    if mode == BACKEND_RTK:
+        if not is_rtk_available():
+            raise RtkNotInstalledError(
+                "HERMES_TOKEN_SAVER=rtk but `rtk` was not found on PATH. "
+                "Install https://github.com/rtk-ai/rtk or switch to native/auto."
+            )
+        return ["rtk", *argv_list]
+    # auto
+    if is_rtk_available() and argv_list[0] in RTK_COMPATIBLE_COMMANDS:
+        return ["rtk", *argv_list]
+    return argv_list
+
+
+def describe() -> dict:
+    backend = resolve_backend()
+    available = is_rtk_available()
+    effective = (
+        BACKEND_RTK
+        if (backend == BACKEND_RTK or (backend == BACKEND_AUTO and available))
+        else BACKEND_NATIVE
+    )
+    return {
+        "backend": backend,
+        "rtk_available": available,
+        "rtk_path": shutil.which("rtk"),
+        "effective": effective,
+    }
+
+
+def iter_compatible_commands() -> Iterable[str]:
+    return iter(sorted(RTK_COMPATIBLE_COMMANDS))
+
+
+__all__ = [
+    "BACKEND_AUTO",
+    "BACKEND_NATIVE",
+    "BACKEND_RTK",
+    "ENV_BACKEND",
+    "RTK_COMPATIBLE_COMMANDS",
+    "RtkNotInstalledError",
+    "VALID_BACKENDS",
+    "describe",
+    "is_rtk_available",
+    "iter_compatible_commands",
+    "resolve_backend",
+    "wrap_command",
+]

--- a/docs/integrations/rtk-bridge.md
+++ b/docs/integrations/rtk-bridge.md
@@ -1,0 +1,47 @@
+# RTK Compatibility Bridge
+
+Optional bridge for the [RTK token-saver CLI](https://github.com/rtk-ai/rtk).
+When `rtk` is on `PATH`, shell-heavy commands can be routed through `rtk <cmd>`
+to cut tokens spent on verbose output. Without `rtk` installed, Hermes Turbo
+keeps its native behaviour — RTK is never required.
+
+## Backend modes
+
+Configured via `HERMES_TOKEN_SAVER`:
+
+- `auto` (default): use `rtk` when detected and the command is allow-listed.
+- `rtk`: always wrap with `rtk`; raises if missing.
+- `native`: never use `rtk`.
+
+Allow-list: `read`, `grep`, `find`, `git`, `npx`, `ls`, `cat`, `head`, `tail`.
+
+## Quick check
+
+```bash
+scripts/check-rtk.sh
+# backend=auto / rtk_available=1 / rtk_path=... / effective=rtk
+```
+
+Exit codes: `0` rtk active, `1` native fallback, `2` rtk requested but missing.
+
+## Programmatic use
+
+```python
+from agent.adapters.rtk_bridge import wrap_command, describe
+
+argv = wrap_command(["git", "log", "-n", "10"])
+# -> ["rtk", "git", "log", "-n", "10"] when rtk available under auto/rtk
+# -> ["git", "log", "-n", "10"]        otherwise
+```
+
+`wrap_command` is pure — the caller still executes the resulting argv.
+
+## Safety
+
+- Opt-in by env var; `native` disables without uninstalling.
+- Allow-list, not denylist: new commands need an explicit code change.
+- Evidence-bearing commands (Playwright traces, screenshots, streaming logs)
+  should bypass the bridge to preserve raw output.
+- `rtk` mode raises `RtkNotInstalledError` instead of silent fallback.
+
+Issue: <https://github.com/wesleysimplicio/hermes-turbo-agent/issues/94>

--- a/scripts/check-rtk.sh
+++ b/scripts/check-rtk.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# check-rtk.sh — show which token-saver backend the Hermes Turbo RTK bridge
+# will use. See docs/integrations/rtk-bridge.md.
+#
+# Exit: 0 rtk active, 1 native fallback, 2 backend=rtk but rtk missing.
+set -euo pipefail
+
+BACKEND="${HERMES_TOKEN_SAVER:-auto}"
+
+if command -v rtk >/dev/null 2>&1; then
+  RTK_PATH="$(command -v rtk)"
+  RTK_AVAILABLE=1
+else
+  RTK_PATH=""
+  RTK_AVAILABLE=0
+fi
+
+case "$BACKEND" in
+  native) EFFECTIVE="native" ;;
+  rtk)
+    if [ "$RTK_AVAILABLE" -eq 1 ]; then
+      EFFECTIVE="rtk"
+    else
+      echo "ERROR: HERMES_TOKEN_SAVER=rtk but \`rtk\` is not on PATH." >&2
+      echo "Install https://github.com/rtk-ai/rtk or switch to native/auto." >&2
+      exit 2
+    fi
+    ;;
+  auto|*)
+    BACKEND="auto"
+    [ "$RTK_AVAILABLE" -eq 1 ] && EFFECTIVE="rtk" || EFFECTIVE="native"
+    ;;
+esac
+
+printf 'backend=%s\nrtk_available=%s\nrtk_path=%s\neffective=%s\n' \
+  "$BACKEND" "$RTK_AVAILABLE" "$RTK_PATH" "$EFFECTIVE"
+
+[ "$EFFECTIVE" = "rtk" ] && exit 0 || exit 1

--- a/tests/agent/adapters/test_rtk_bridge.py
+++ b/tests/agent/adapters/test_rtk_bridge.py
@@ -1,0 +1,100 @@
+"""Unit tests for the RTK compatibility bridge."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent.adapters import rtk_bridge  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv(rtk_bridge.ENV_BACKEND, raising=False)
+
+
+def _which(value):
+    return lambda name: value if name == "rtk" else None
+
+
+def test_is_rtk_available_true(monkeypatch):
+    monkeypatch.setattr(rtk_bridge.shutil, "which", _which("/usr/local/bin/rtk"))
+    assert rtk_bridge.is_rtk_available() is True
+
+
+def test_is_rtk_available_false(monkeypatch):
+    monkeypatch.setattr(rtk_bridge.shutil, "which", _which(None))
+    assert rtk_bridge.is_rtk_available() is False
+
+
+def test_resolve_backend_default_and_env(monkeypatch):
+    assert rtk_bridge.resolve_backend() == rtk_bridge.BACKEND_AUTO
+    monkeypatch.setenv(rtk_bridge.ENV_BACKEND, "native")
+    assert rtk_bridge.resolve_backend() == rtk_bridge.BACKEND_NATIVE
+    assert rtk_bridge.resolve_backend("rtk") == rtk_bridge.BACKEND_RTK
+    assert rtk_bridge.resolve_backend("garbage") == rtk_bridge.BACKEND_AUTO
+
+
+def test_wrap_native_passthrough(monkeypatch):
+    monkeypatch.setattr(rtk_bridge.shutil, "which", _which("/usr/local/bin/rtk"))
+    assert rtk_bridge.wrap_command(["git", "status"], backend="native") == ["git", "status"]
+
+
+def test_wrap_rtk_available(monkeypatch):
+    monkeypatch.setattr(rtk_bridge.shutil, "which", _which("/usr/local/bin/rtk"))
+    assert rtk_bridge.wrap_command(["git", "status"], backend="rtk") == ["rtk", "git", "status"]
+
+
+def test_wrap_rtk_missing_raises(monkeypatch):
+    monkeypatch.setattr(rtk_bridge.shutil, "which", _which(None))
+    with pytest.raises(rtk_bridge.RtkNotInstalledError):
+        rtk_bridge.wrap_command(["git", "status"], backend="rtk")
+
+
+def test_wrap_auto_compatible(monkeypatch):
+    monkeypatch.setattr(rtk_bridge.shutil, "which", _which("/usr/local/bin/rtk"))
+    assert rtk_bridge.wrap_command(["git", "log"], backend="auto") == ["rtk", "git", "log"]
+
+
+def test_wrap_auto_skips_incompatible(monkeypatch):
+    monkeypatch.setattr(rtk_bridge.shutil, "which", _which("/usr/local/bin/rtk"))
+    assert rtk_bridge.wrap_command(["psql", "-c", "select 1"], backend="auto") == ["psql", "-c", "select 1"]
+
+
+def test_wrap_auto_no_rtk(monkeypatch):
+    monkeypatch.setattr(rtk_bridge.shutil, "which", _which(None))
+    assert rtk_bridge.wrap_command(["grep", "x", "f"], backend="auto") == ["grep", "x", "f"]
+
+
+def test_wrap_empty_argv():
+    assert rtk_bridge.wrap_command([], backend="rtk") == []
+
+
+def test_describe(monkeypatch):
+    monkeypatch.setattr(rtk_bridge.shutil, "which", _which("/opt/rtk/rtk"))
+    info = rtk_bridge.describe()
+    assert info == {
+        "backend": "auto",
+        "rtk_available": True,
+        "rtk_path": "/opt/rtk/rtk",
+        "effective": "rtk",
+    }
+
+
+def test_describe_native_fallback(monkeypatch):
+    monkeypatch.setattr(rtk_bridge.shutil, "which", _which(None))
+    info = rtk_bridge.describe()
+    assert info["rtk_available"] is False
+    assert info["effective"] == "native"
+
+
+def test_iter_compatible_sorted():
+    cmds = list(rtk_bridge.iter_compatible_commands())
+    assert cmds == sorted(cmds)
+    assert "git" in cmds


### PR DESCRIPTION
Tracks #94 — previously closed without commits, reopened to deliver real implementation.

## Scope
Add RTK compatibility and external token-saver bridge

## Status
Scaffold only. Implementation plan in `.plans/issue-94-add-rtk-compatibility-and-external-token-saver-bridge.md`. Will be expanded in follow-up commits until DoD is green.

Refs #94