### PR TITLE
track(#95): Add compression safety evaluation suite for token saver outputs

### DIFF
--- a/.plans/issue-95-add-compression-safety-evaluation-suite-for-token-saver-outp.md
+++ b/.plans/issue-95-add-compression-safety-evaluation-suite-for-token-saver-outp.md
@@ -1,0 +1,35 @@
+# Issue #95: Add compression safety evaluation suite for token saver outputs
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/95
+
+## Original description (excerpt)
+
+```
+## Goal
+Ensure token compression does not hide the exact information needed to fix bugs, review code, or close issues.
+
+## Context
+A token-saver is only useful if it preserves debugging signal. Hermes Turbo needs regression fixtures that compare raw output against compressed output for common workflows.
+
+## Acceptance criteria
+- Add fixtures for failing tests, lint errors, type errors, CI logs, diffs, grep output, GitHub PR reviews, and long logs.
+- Define required retained signals for each fixture type.
+- Test `safe`, `balanced`, and `aggressive` modes separately.
+- Include adversarial cases such as repeated errors with one unique root cause, warnings before fatal errors, and secret-like values.
+- Add a contributor guide for writing new compression adapters safely.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/docs/eval/compression-safety.md
+++ b/docs/eval/compression-safety.md
@@ -1,0 +1,65 @@
+# Compression safety evaluation suite
+
+Goal: guarantee the token-saver never erases the exact signal an agent (or a
+human reviewer) needs to fix a bug, review code, or close an issue. If we lose
+a stack trace line, a rule id, or a file path, the saver is a regression, not
+an optimization.
+
+## Layout
+
+```
+tests/eval/compression_safety/
+  runner.py                 # entrypoint, exits non-zero if any fixture fails
+  fixtures/*.json           # golden samples — input + expected_preserved
+```
+
+Each fixture is a JSON document with:
+
+| field                | type        | meaning                                              |
+| -------------------- | ----------- | ---------------------------------------------------- |
+| `name`               | string      | Short identifier for the case.                       |
+| `kind`               | string      | Category (test_output, lint_output, ci_log, etc.).   |
+| `input`              | string      | Raw text fed to the compressor.                      |
+| `expected_preserved` | list[string]| Substrings the compressed output MUST still contain. |
+
+## Run
+
+```bash
+python3 tests/eval/compression_safety/runner.py
+```
+
+The default compressor (`collapse_repeated_lines`) is deterministic and ships
+inside `runner.py`, so the suite is hermetic — it runs in CI without any extra
+install.
+
+To evaluate a real adapter (safe / balanced / aggressive mode) point the
+runner at a callable:
+
+```bash
+python3 tests/eval/compression_safety/runner.py \
+  --compressor mypkg.compressor:safe_mode
+```
+
+The callable must accept `str` and return `str`. Exit code is `0` when every
+fixture keeps every preserved substring, `1` otherwise.
+
+## Adding a new fixture
+
+1. Drop a new `NN_<slug>.json` file into `fixtures/`. Synthetic data only — no
+   real secrets, no production payloads.
+2. List every literal substring a reviewer would need to triage the case in
+   `expected_preserved`. Prefer specific tokens (rule id, file:line, error
+   code) over prose.
+3. Re-run the suite. Green = adapter handles your case. Red = either the
+   adapter is unsafe or the fixture is over-strict; pick one and justify it
+   in the PR.
+
+## Authoring guidance for compressor adapters
+
+- Never collapse a line that is the only occurrence of a unique identifier
+  (rule id, error code, file path, line number, exception name).
+- Repeated warnings are fair game; the first occurrence + a count is enough.
+- Adversarial cases to keep in the suite: warnings preceding fatal errors,
+  many repeated errors hiding one unique root cause, secret-shaped strings
+  (tokens, JWTs) that must be redacted but not silently dropped.
+- A new adapter ships with a fixture that exercises its mode.

--- a/tests/eval/compression_safety/fixtures/01_failing_test.json
+++ b/tests/eval/compression_safety/fixtures/01_failing_test.json
@@ -1,0 +1,13 @@
+{
+  "name": "failing_test_pytest",
+  "kind": "test_output",
+  "input": "============================= test session starts ==============================\nplatform linux -- Python 3.11.4, pytest-8.0.0\ncollected 42 items\n\ntests/test_auth.py ........F.....                                        [ 33%]\ntests/test_db.py ............                                             [ 66%]\ntests/test_api.py ..............                                          [100%]\n\n=================================== FAILURES ===================================\n___________________ test_login_rejects_expired_token ___________________\n\n    def test_login_rejects_expired_token():\n        token = make_token(expired=True)\n>       assert login(token) == 401\nE       AssertionError: assert 200 == 401\nE        +  where 200 = login('eyJhbGciOi...expired')\n\ntests/test_auth.py:87: AssertionError\n=========================== 1 failed, 41 passed in 3.21s ===========================",
+  "expected_preserved": [
+    "test_login_rejects_expired_token",
+    "AssertionError",
+    "tests/test_auth.py:87",
+    "401",
+    "1 failed",
+    "expired"
+  ]
+}

--- a/tests/eval/compression_safety/fixtures/02_lint_errors.json
+++ b/tests/eval/compression_safety/fixtures/02_lint_errors.json
@@ -1,0 +1,13 @@
+{
+  "name": "lint_errors_eslint",
+  "kind": "lint_output",
+  "input": "/repo/src/auth/login.ts\n  12:3   error    'token' is defined but never used         no-unused-vars\n  45:18  error    Missing return type on function          @typescript-eslint/explicit-function-return-type\n  67:1   warning  Unexpected console statement             no-console\n\n/repo/src/db/pool.ts\n  8:5    error    'connect' is not exported from 'pg'      import/named\n\nrepeated warning: 'console' usage in 14 other files\nrepeated warning: 'console' usage in 14 other files\nrepeated warning: 'console' usage in 14 other files\nrepeated warning: 'console' usage in 14 other files\n\n4 problems (3 errors, 1 warning)",
+  "expected_preserved": [
+    "no-unused-vars",
+    "explicit-function-return-type",
+    "import/named",
+    "src/auth/login.ts",
+    "src/db/pool.ts",
+    "3 errors"
+  ]
+}

--- a/tests/eval/compression_safety/fixtures/03_type_errors.json
+++ b/tests/eval/compression_safety/fixtures/03_type_errors.json
@@ -1,0 +1,14 @@
+{
+  "name": "type_errors_mypy",
+  "kind": "typecheck_output",
+  "input": "src/payments/charge.py:42: error: Argument 1 to \"charge\" has incompatible type \"str\"; expected \"Decimal\"  [arg-type]\nsrc/payments/charge.py:51: error: Item \"None\" of \"Optional[Customer]\" has no attribute \"id\"  [union-attr]\nsrc/payments/refund.py:18: error: Missing return statement  [return]\nsrc/payments/refund.py:33: note: Hint: use Decimal(str(value)) to avoid float precision issues\nFound 3 errors in 2 files (checked 87 source files)",
+  "expected_preserved": [
+    "src/payments/charge.py:42",
+    "src/payments/charge.py:51",
+    "src/payments/refund.py:18",
+    "arg-type",
+    "union-attr",
+    "Decimal",
+    "3 errors"
+  ]
+}

--- a/tests/eval/compression_safety/fixtures/04_ci_log_adversarial.json
+++ b/tests/eval/compression_safety/fixtures/04_ci_log_adversarial.json
@@ -1,0 +1,12 @@
+{
+  "name": "ci_log_warnings_then_fatal",
+  "kind": "ci_log",
+  "input": "::group::Install\nnpm WARN deprecated package@1.0.0\nnpm WARN deprecated other@2.0.0\nnpm WARN deprecated foo@3.0.0\nnpm WARN deprecated bar@4.0.0\nnpm WARN deprecated baz@5.0.0\nnpm WARN deprecated qux@6.0.0\nnpm WARN deprecated quux@7.0.0\nnpm WARN deprecated corge@8.0.0\n::endgroup::\n::group::Build\n> tsc -b\nsrc/index.ts(102,5): error TS2532: Object is possibly 'undefined'.\n::endgroup::\nError: Process completed with exit code 2.\nfatal: build failed for commit abc123",
+  "expected_preserved": [
+    "TS2532",
+    "src/index.ts(102,5)",
+    "exit code 2",
+    "fatal",
+    "build failed"
+  ]
+}

--- a/tests/eval/compression_safety/fixtures/05_grep_diff.json
+++ b/tests/eval/compression_safety/fixtures/05_grep_diff.json
@@ -1,0 +1,13 @@
+{
+  "name": "grep_diff_mixed",
+  "kind": "grep_diff",
+  "input": "src/auth/login.ts:42:  const token = req.headers.authorization;\nsrc/auth/login.ts:43:  if (!token) return res.status(401).send('no token');\nsrc/auth/login.ts:44:  const claims = jwt.verify(token, SECRET);\n\ndiff --git a/src/auth/login.ts b/src/auth/login.ts\nindex 1234abc..5678def 100644\n--- a/src/auth/login.ts\n+++ b/src/auth/login.ts\n@@ -42,3 +42,4 @@ export function login(req, res) {\n   const token = req.headers.authorization;\n-  if (!token) return res.status(401).send('no token');\n+  if (!token) return res.status(401).json({ error: 'no token' });\n+  log.info('login attempt');\n   const claims = jwt.verify(token, SECRET);",
+  "expected_preserved": [
+    "src/auth/login.ts",
+    "jwt.verify",
+    "401",
+    "no token",
+    "@@ -42",
+    "log.info"
+  ]
+}

--- a/tests/eval/compression_safety/runner.py
+++ b/tests/eval/compression_safety/runner.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Compression safety evaluation runner.
+
+Loads golden fixtures from ``fixtures/`` and validates that every
+``expected_preserved`` substring still appears in the compressed output of a
+token-saver pass. The default compressor is a deterministic heuristic
+(``collapse_repeated_lines``) so the suite runs without external dependencies.
+
+A different compressor can be injected via the ``--compressor`` flag for
+adapters that ship later (safe / balanced / aggressive modes). Each adapter
+must accept ``str -> str``.
+
+Exit status: 0 if every fixture preserves its required signals, 1 otherwise.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def collapse_repeated_lines(text: str) -> str:
+    """Default safe compressor: drop adjacent duplicate lines and trim trailing whitespace."""
+    out: list[str] = []
+    prev: str | None = None
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if line == prev:
+            continue
+        out.append(line)
+        prev = line
+    return "\n".join(out)
+
+
+def load_compressor(spec: str | None) -> Callable[[str], str]:
+    if not spec:
+        return collapse_repeated_lines
+    module_name, _, attr = spec.rpartition(":")
+    if not module_name:
+        raise ValueError(f"compressor spec must be 'module:callable', got {spec!r}")
+    module = importlib.import_module(module_name)
+    fn = getattr(module, attr)
+    if not callable(fn):
+        raise TypeError(f"{spec} is not callable")
+    return fn
+
+
+def evaluate_fixture(fixture: dict[str, Any], compressor: Callable[[str], str]) -> list[str]:
+    """Return a list of missing preserved tokens. Empty list means pass."""
+    compressed = compressor(fixture["input"])
+    return [needle for needle in fixture["expected_preserved"] if needle not in compressed]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--compressor",
+        default=None,
+        help="Importable callable 'module.path:func' that takes str -> str.",
+    )
+    parser.add_argument(
+        "--fixtures",
+        default=str(FIXTURES_DIR),
+        help="Directory with golden JSON fixtures.",
+    )
+    args = parser.parse_args(argv)
+
+    fixtures_path = Path(args.fixtures)
+    files = sorted(fixtures_path.glob("*.json"))
+    if not files:
+        print(f"no fixtures found under {fixtures_path}", file=sys.stderr)
+        return 2
+
+    compressor = load_compressor(args.compressor)
+    failures: list[tuple[str, list[str]]] = []
+    for fx_path in files:
+        fixture = json.loads(fx_path.read_text(encoding="utf-8"))
+        missing = evaluate_fixture(fixture, compressor)
+        status = "OK" if not missing else "FAIL"
+        print(f"[{status}] {fixture['name']} ({fixture['kind']})")
+        if missing:
+            for needle in missing:
+                safe = re.sub(r"\s+", " ", needle)[:120]
+                print(f"        missing: {safe!r}")
+            failures.append((fixture["name"], missing))
+
+    print()
+    print(f"fixtures: {len(files)}  failures: {len(failures)}")
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    sys.exit(main())


### PR DESCRIPTION
Tracks #95 — previously closed without commits, reopened to deliver real implementation.

## Scope
Add compression safety evaluation suite for token saver outputs

## Status
Scaffold only. Implementation plan in `.plans/issue-95-add-compression-safety-evaluation-suite-for-token-saver-outp.md`. Will be expanded in follow-up commits until DoD is green.

Refs #95