### PR TITLE
track(#97): Add distributed node host architecture for remote execution parity

### DIFF
--- a/.plans/issue-97-add-distributed-node-host-architecture-for-remote-execution-.md
+++ b/.plans/issue-97-add-distributed-node-host-architecture-for-remote-execution-.md
@@ -1,0 +1,32 @@
+# Issue #97: Add distributed node host architecture for remote execution parity
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/97
+
+## Original description (excerpt)
+
+```
+## Goal
+Close the OpenClaw Gateway + Nodes advantage with a Hermes Turbo node-host architecture for remote execution, browser, desktop, and car surfaces.
+
+## Acceptance criteria
+- Define Gateway/daemon/client/node roles for Hermes Turbo.
+- Add a typed node capability registry for `system.run`, browser, screen, location, notifications, and platform-specific commands.
+- Include pairing/auth/approval requirements.
+- Keep node execution isolated from the model-facing agent loop.
+- Add an ADR and prototype plan before production implementation.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/agent/distributed/__init__.py
+++ b/agent/distributed/__init__.py
@@ -1,0 +1,23 @@
+"""Distributed node host package.
+
+See `docs/adr/0006-distributed-node-host.md` for the architecture
+and `docs/distributed/overview.md` for the operator-facing summary.
+
+This module currently exposes only the wire-protocol dataclasses
+(`agent.distributed.protocol`). Gateway and node-runtime implementations
+land in follow-up PRs per the ADR prototype plan.
+"""
+
+from agent.distributed.protocol import (
+    HealthPing,
+    NodeRegister,
+    TaskDispatch,
+    TaskResult,
+)
+
+__all__ = [
+    "HealthPing",
+    "NodeRegister",
+    "TaskDispatch",
+    "TaskResult",
+]

--- a/agent/distributed/protocol.py
+++ b/agent/distributed/protocol.py
@@ -1,0 +1,172 @@
+"""Wire-protocol dataclasses for the distributed node host.
+
+These are **types only**. No transport, no serialization helpers, no
+behavior beyond what `@dataclass(slots=True, frozen=True)` provides.
+See `docs/adr/0006-distributed-node-host.md` for the contract and
+`docs/distributed/overview.md` for the operator-facing summary.
+
+The shapes here are designed to be msgspec-compatible: every field uses
+primitives or other dataclasses, no `Any`, no `dict[str, object]` at
+the top level. When the gateway lands we add a thin
+`msgspec.Struct`-based encoder pair alongside these definitions rather
+than replacing them, so static consumers keep working.
+
+Protocol version is tracked via `PROTOCOL_VERSION` below. Any field
+addition or removal is a protocol-version bump and lands in a follow-up
+ADR.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+PROTOCOL_VERSION: int = 1
+"""Wire-protocol version. Bumped on any breaking change to the
+dataclasses in this module. Nodes and gateways exchange this in
+`NodeRegister` and refuse mismatched majors."""
+
+
+class Surface(str, Enum):
+    """Physical surface a node runs on."""
+
+    DESKTOP = "desktop"
+    CAR = "car"
+    MOBILE = "mobile"
+    BROWSER_POD = "browser_pod"
+    HEADLESS = "headless"
+
+
+class Lane(str, Enum):
+    """Execution lane (yool spec section 6). Drives queue selection."""
+
+    FAST = "fast"
+    SLOW = "slow"
+    BACKGROUND = "background"
+
+
+class Authority(str, Enum):
+    """Capability authority level (yool spec section 5)."""
+
+    DEV = "dev"
+    OPS = "ops"
+    REVIEW = "review"
+    AUDIT = "audit"
+
+
+@dataclass(slots=True, frozen=True)
+class AgentTerms:
+    """Mandatory guardrails declared per capability.
+
+    Per the yool spec (sections 11.1 and 11.2) `cpu_quota_pct` and
+    `disk_quota_mb` are mandatory. A capability that omits them is
+    rejected at `NodeRegister`. Victor Genaro's review: "precisa de
+    guardrail pra nao fritar o processador. Voce precisa de garbage
+    collector tambem pra nao encher 100% do disco."
+    """
+
+    cpu_quota_pct: int
+    disk_quota_mb: int
+    timeout_s: int = 30
+
+
+@dataclass(slots=True, frozen=True)
+class Capability:
+    """One typed capability a node exposes.
+
+    `yool_id` follows `capability.<surface>.<verb>` and is used as the
+    HAMT key in the registry (ADR-0006 section 4).
+    """
+
+    yool_id: str
+    authority: Authority
+    lane: Lane
+    agent_terms: AgentTerms
+
+
+@dataclass(slots=True, frozen=True)
+class NodeRegister:
+    """Sent node -> gateway on connect and on every capability change.
+
+    The gateway rejects the message if `protocol_version` major does
+    not match `PROTOCOL_VERSION`, if `auth_token` is unknown, or if any
+    capability omits mandatory `agent_terms` fields.
+    """
+
+    node_id: str
+    surface: Surface
+    capabilities: tuple[Capability, ...]
+    auth_token: str
+    protocol_version: int = PROTOCOL_VERSION
+
+
+@dataclass(slots=True, frozen=True)
+class TaskDispatch:
+    """Sent control plane -> gateway -> node.
+
+    `payload` is opaque to the gateway; only the destination node
+    parses it. `approval_token` is required for sensitive capabilities
+    (see ADR-0006 section 3) and is scoped to one capability + one node
+    + one payload hash. Secrets MUST NOT appear inline; reference them
+    by alias resolved against the node's local keystore.
+    """
+
+    task_id: str
+    capability: str  # yool_id
+    payload: bytes
+    deadline_s: float
+    idempotency_key: str
+    approval_token: str | None = None
+
+
+TaskStatus = Literal["ok", "error", "timeout", "denied"]
+
+
+@dataclass(slots=True, frozen=True)
+class TaskResult:
+    """Sent node -> gateway -> control plane.
+
+    `result_payload` is opaque to the gateway. `error` is populated
+    only when `status != "ok"`.
+    """
+
+    task_id: str
+    node_id: str
+    status: TaskStatus
+    result_payload: bytes
+    elapsed_ms: int
+    error: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class HealthPing:
+    """Bidirectional liveness + load signal.
+
+    Missing 3 consecutive pings marks the node degraded; missing 6
+    evicts it (ADR-0006 section 5). Quotas are reported as percentages
+    of the limits declared in `Capability.agent_terms` so the gateway
+    can apply backpressure without knowing the absolute machine size.
+    """
+
+    node_id: str
+    ts: float
+    inflight_count: int
+    cpu_pct: float
+    mem_pct: float
+    disk_pct: float
+
+
+__all__ = [
+    "PROTOCOL_VERSION",
+    "AgentTerms",
+    "Authority",
+    "Capability",
+    "HealthPing",
+    "Lane",
+    "NodeRegister",
+    "Surface",
+    "TaskDispatch",
+    "TaskResult",
+    "TaskStatus",
+]

--- a/docs/adr/0006-distributed-node-host.md
+++ b/docs/adr/0006-distributed-node-host.md
@@ -1,0 +1,100 @@
+# ADR-0006: Distributed node host architecture
+
+**Status:** Proposed.
+**Date:** 2026-05-21.
+**Owner:** @wesleysimplicio.
+**Related:** GitHub issue #97. Builds on ADR-0005 (prompt-cache stable prefix) for control-plane prompt assembly, and ADR-0004 (perf budgets) for node-side execution budgets.
+
+## Context
+
+OpenClaw ships a Gateway + Nodes architecture that lets a single agent loop drive `system.run`, browser automation, screen/location capture, notifications, and platform-specific commands on **remote** surfaces (desktop, car, mobile) while keeping the model-facing loop isolated from device IO. Hermes Turbo today executes everything in-process: tools that touch local hardware (browser, OS shell, camera, GPS, notifications) only work where the agent process runs. That blocks the desktop + car + remote-browser surfaces in `PERFORMANCE_ROADMAP.md`.
+
+Issue #97 asks for parity: define a Gateway/daemon/client/node split, a typed capability registry, pairing/auth/approval semantics, and an ADR + prototype plan **before** any production code lands.
+
+## Decision
+
+Adopt a two-plane architecture with a typed RPC contract and capability addressing.
+
+### 1. Plane split
+
+- **Control plane** — owns the model-facing agent loop, prompt assembly, history, skills, and policy. Single process per session. Never executes a node tool directly; emits typed `TaskDispatch` envelopes.
+- **Node plane** — one or more *nodes*, each registered with a typed capability set (`system.run`, `browser.*`, `screen.capture`, `location.read`, `notifications.send`, `platform.<surface>.*`). A node runs on the surface that owns the capability (desktop, car head-unit, phone, headless browser pod).
+- **Gateway** — the only thing the control plane talks to. Multiplexes many nodes, persists pairing state, enforces approval, and exposes the same `dispatch / result / health` surface to the agent loop regardless of node count.
+
+A node is **never** loaded into the agent's Python module graph. The agent loop cannot import node code; it can only address a capability over the wire. This guarantees the existing isolation property (no `subprocess.Popen` from the model loop) is preserved as we scale to N surfaces.
+
+### 2. RPC contract
+
+Four message types form the wire protocol. Types live in `agent/distributed/protocol.py` (this PR ships dataclass skeletons; impl deferred):
+
+- `NodeRegister` — node to gateway. Declares `node_id`, `surface`, `capabilities[]`, `auth_token`, `protocol_version`. Sent on connect + on every capability change.
+- `TaskDispatch` — control plane to gateway to node. Carries `task_id`, `capability` (yool id, see section 4), `payload`, `approval_token`, `deadline_s`, `idempotency_key`.
+- `TaskResult` — node to gateway to control plane. Carries `task_id`, `status` (`ok|error|timeout|denied`), `result_payload`, `error`, `elapsed_ms`, `node_id`.
+- `HealthPing` — bidirectional. Carries `node_id`, `ts`, `inflight_count`, `cpu_pct`, `mem_pct`, `disk_pct`. Drives failover (section 5).
+
+Wire format: msgspec-encoded JSON over a single long-lived bidirectional stream (gRPC-style, but transport is HTTP/2 + JSON for now — keeps debugging trivial and aligns with `_fastjson`). Transport-level changes do not require ADR revisions; payload schema changes do.
+
+### 3. Auth + pairing + approval
+
+Three layers, all required:
+
+1. **Pairing** — first contact between a node and the gateway uses an out-of-band pairing code (short-lived, single-use, displayed on the gateway operator's screen / car HUD). On success the node receives a long-lived `auth_token` scoped to that gateway. Tokens are revocable.
+2. **Authn** — every `NodeRegister` / `TaskDispatch` carries `auth_token`. Gateway rejects unknown tokens. Nodes reject dispatches from gateways they did not pair with.
+3. **Approval** — sensitive capabilities (`system.run`, `screen.capture`, `location.read`, anything writing files outside a sandbox) require a per-task `approval_token` minted by the human-in-the-loop UI on the controlling surface. Approval tokens are scoped to one capability + one node + one payload-hash and expire in seconds. The agent loop **cannot** mint approval tokens itself.
+
+Secrets never appear in `TaskDispatch.payload`. Credentials live in the node's local keystore; the dispatch references them by alias.
+
+### 4. Capability addressing (yool / tuple / HAMT)
+
+Capabilities are addressed using the yool/tuple/HAMT scheme adopted in this repo (spec at https://github.com/wesleysimplicio/yool-tuple-hamt). Each capability declares:
+
+```
+yool_id: capability.<surface>.<verb>     # e.g. capability.desktop.system.run
+authority: dev | ops | review | audit
+lane: fast | slow | background
+agent_terms:
+    cpu_quota_pct: <int, MANDATORY>      # spec section 11.1
+    disk_quota_mb: <int, MANDATORY>      # spec section 11.2
+    timeout_s: <int>
+```
+
+The capability registry is a HAMT keyed on `yool_id`; lookup is O(log32 N) and immutable per-version, so the agent loop can take a snapshot at task start and the registry can update concurrently without races. Guardrails (`cpu_quota_pct`, `disk_quota_mb`) are **mandatory** per the yool spec — a node that registers a capability without them is rejected at `NodeRegister`.
+
+### 5. Failover + state sync
+
+State is split by ownership:
+
+- **Control plane state** (conversation history, skills, prompt cache anchors) lives only in the control plane. Nodes are stateless across tasks except for capability-local resources (open browser tabs, mounted screen capture pipes). Crash of one node never loses agent state.
+- **Gateway state** (pairing table, in-flight task ledger, capability registry snapshot) is persisted to a local SQLite file with WAL and replicated to a sibling gateway when configured. Failover is leader/follower; the follower replays the in-flight ledger and re-routes orphaned dispatches once it observes a leader-down signal for `>health_timeout_s`.
+- **Node-local resources** are reconciled on reconnect: the gateway sends `NodeRegister` ACK with the list of in-flight `task_id`s it believes the node owns; the node replies with the actual set and the gateway issues `TaskResult{status=error, error="orphaned"}` for the delta.
+
+`HealthPing` drives liveness: missing 3 consecutive pings (default 9s wall) -> node marked degraded; missing 6 -> evicted; in-flight tasks fan out to other nodes with the same capability if any, otherwise return `status=timeout`.
+
+## Consequences
+
+- **Positive.** Parity with OpenClaw on remote surfaces. Agent loop stays isolated from device IO. Failure of one surface (car head-unit goes offline) does not crash the agent. Auth is explicit and revocable. Capability addressing is typed end-to-end.
+- **Negative.** Adds a wire protocol the team must version and debug. Latency floor for a dispatched task is bounded by network RTT + queue depth, not local syscalls — so latency-critical capabilities (key remapping, IME hooks) stay in-process and are explicitly out of scope for the node plane. Pairing UX must work on surfaces without keyboards (car HUD) — addressed by short numeric pairing codes + QR fallback.
+- **Cost.** Gateway is a new operational component. We will bundle it in the existing `hermes` CLI as `hermes gateway run` rather than ship a separate package.
+
+## Out of scope (this ADR)
+
+- Concrete transport tuning (HTTP/2 vs QUIC vs WebSocket) — chosen during prototype, not ADR-level.
+- Specific node implementations (browser pod, desktop daemon, car runtime).
+- UI/UX of the approval dialog.
+- Multi-tenant gateway (one gateway = one operator for now).
+
+## Alternatives considered
+
+1. **In-process tool plugins with subprocess fan-out.** Rejected: violates the isolation property and does not address remote surfaces.
+2. **MCP-only.** MCP works for tool surface but does not model pairing, approval, or failover across long-lived remote nodes. MCP tools continue to be exposed where they fit; the node host is the layer underneath.
+3. **OpenClaw Gateway as-is, wrapped.** Rejected: license + dependency footprint, and the typed capability model in OpenClaw differs from yool/HAMT enough that a thin wrapper would leak both abstractions.
+
+## Prototype plan
+
+1. Land this ADR + protocol skeleton (this PR).
+2. Prototype gateway in `agent/distributed/gateway.py` with SQLite ledger and a single in-process loopback node. No real network yet.
+3. Add `agent/distributed/node_runtime.py` with one real capability: `system.run` on the local desktop. Pairing via terminal.
+4. Add E2E test that dispatches `system.run` from the agent loop, observes `TaskResult`, and asserts isolation (agent process never `Popen`s anything).
+5. Iterate: browser node, screen capture node, car runtime.
+
+Production rollout is gated on a separate ADR ("ADR-0007: Node host GA criteria") once steps 2–4 are green.

--- a/docs/distributed/overview.md
+++ b/docs/distributed/overview.md
@@ -1,0 +1,71 @@
+# Distributed node host — overview
+
+Operator-facing summary of the distributed node host. Architecture and trade-offs live in [`docs/adr/0006-distributed-node-host.md`](../adr/0006-distributed-node-host.md); wire types live in [`agent/distributed/protocol.py`](../../agent/distributed/protocol.py).
+
+## What it is
+
+Hermes Turbo splits work between a **control plane** (the agent loop, prompt assembly, history, skills) and a **node plane** (the surfaces that touch real hardware — desktop, car head-unit, mobile, headless browser pod). A **gateway** sits in the middle and gives the control plane one connection no matter how many nodes are paired.
+
+```
++-----------------+        +-----------+        +-----------+
+|  control plane  | <----> |  gateway  | <----> |  node A   |
+|  (agent loop)   |        |           | <----> |  node B   |
++-----------------+        +-----------+ <----> |  node C   |
+                                                +-----------+
+```
+
+The agent loop never imports node code and never spawns a subprocess. It addresses a capability by yool id (`capability.<surface>.<verb>`) and the gateway routes the dispatch to a node that owns it.
+
+## Roles
+
+- **Control plane.** Runs the model-facing loop. Holds conversation state, skills, the prompt-cache stable prefix (see ADR-0005). Emits `TaskDispatch` envelopes; consumes `TaskResult`.
+- **Gateway.** Multiplexes nodes. Owns the capability registry (a HAMT keyed on `yool_id`), the pairing table, the in-flight task ledger (SQLite + WAL), and the approval policy.
+- **Node.** Lives on the surface that owns a capability. Registers its capability set on connect via `NodeRegister`, executes dispatched tasks, returns `TaskResult`. Stateless across tasks except for capability-local resources (open browser tabs, screen-capture pipes).
+
+## Wire types
+
+Four message types, defined in `agent/distributed/protocol.py`:
+
+| Type | Direction | Purpose |
+|------|-----------|---------|
+| `NodeRegister` | node -> gateway | Declare identity, surface, capabilities, auth token, protocol version. |
+| `TaskDispatch` | control -> gateway -> node | Carry one task: capability, payload, approval token, deadline, idempotency key. |
+| `TaskResult` | node -> gateway -> control | Return outcome: `ok|error|timeout|denied`, payload, elapsed ms. |
+| `HealthPing` | bidirectional | Liveness + load signal. Drives degraded/evicted state machine. |
+
+All four are `@dataclass(slots=True, frozen=True)` and msgspec-friendly. Protocol version is tracked in `PROTOCOL_VERSION`; a major mismatch is rejected at registration.
+
+## Auth + approval
+
+Three independent layers. All three must pass:
+
+1. **Pairing.** First contact uses an out-of-band code (short numeric, QR fallback on the car HUD). On success the node receives a long-lived, revocable `auth_token` scoped to that gateway.
+2. **Authn.** Every `NodeRegister` and `TaskDispatch` carries `auth_token`. Unknown token = reject.
+3. **Approval.** Sensitive capabilities (`system.run`, `screen.capture`, `location.read`, anything writing outside a sandbox) require a per-task `approval_token` minted by the human-in-the-loop UI. The agent loop cannot mint approval tokens itself. Tokens are scoped to one capability + one node + one payload hash and expire in seconds.
+
+Secrets never travel in `TaskDispatch.payload`. The dispatch references credentials by alias; the node resolves the alias against its local keystore.
+
+## Guardrails (mandatory)
+
+Every registered capability declares `agent_terms` with `cpu_quota_pct` and `disk_quota_mb` (yool spec sections 11.1 and 11.2). Capabilities without these fields are rejected at `NodeRegister`. This is the same guardrail contract the rest of the agent uses; the node host does not get to opt out.
+
+## Failover
+
+- **Health.** Missing 3 consecutive `HealthPing`s (default 9s) marks a node degraded; missing 6 evicts it.
+- **In-flight tasks** on an evicted node fan out to other nodes with the same capability if any exist. Otherwise the control plane sees `TaskResult{status="timeout"}` and decides whether to retry.
+- **Gateway** persists pairing + in-flight ledger to SQLite (WAL). When configured with a follower, leader/follower replication replays the ledger on failover.
+- **Control plane state never lives on a node**, so any node crash is recoverable. Capability-local resources (browser tabs, screen pipes) reconcile on reconnect.
+
+## What is NOT in this iteration
+
+- No real network transport yet — only the type contract.
+- No gateway implementation; no node runtime. Both land in follow-up PRs per the ADR prototype plan.
+- No multi-tenant gateway. One gateway = one operator.
+- Latency-critical local hooks (IME, key remapping) stay in-process and are explicitly out of scope.
+
+## Pointers
+
+- ADR: `docs/adr/0006-distributed-node-host.md`
+- Types: `agent/distributed/protocol.py`
+- Yool / HAMT spec: https://github.com/wesleysimplicio/yool-tuple-hamt
+- Tracking issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/97


### PR DESCRIPTION
Tracks #97 — previously closed without commits, reopened to deliver real implementation.

## Scope
Add distributed node host architecture for remote execution parity

## Status
Scaffold only. Implementation plan in `.plans/issue-97-add-distributed-node-host-architecture-for-remote-execution-.md`. Will be expanded in follow-up commits until DoD is green.

Refs #97