### PR TITLE
track(#98): Add on-demand tool schema and skill metadata minimization

### DIFF
--- a/.plans/issue-98-add-on-demand-tool-schema-and-skill-metadata-minimization.md
+++ b/.plans/issue-98-add-on-demand-tool-schema-and-skill-metadata-minimization.md
@@ -1,0 +1,32 @@
+# Issue #98: Add on-demand tool schema and skill metadata minimization
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/98
+
+## Original description (excerpt)
+
+```
+## Goal
+Reduce prompt size by exposing only relevant tools and compact skills metadata per turn, while allowing discovery when needed.
+
+## Acceptance criteria
+- Add a policy for visible tool schemas by task, profile, channel, and provider.
+- Add compact skill metadata with explicit character/token budgets.
+- Provide expansion/discovery APIs for hidden tools/skills.
+- Add tests proving irrelevant tools are not included in model prompt assembly.
+- Track token savings from schema minimization.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/agent/registry/__init__.py
+++ b/agent/registry/__init__.py
@@ -1,0 +1,16 @@
+"""Registry helpers for lazy tool schema and skill metadata loading.
+
+See ``docs/perf/lazy-schemas.md``.
+"""
+
+from .lazy_schema import (
+    LazyToolRegistry, ToolStub, list_tools, load_schema, register_tool,
+)
+from .skill_meta import (
+    SkillManifest, SkillRegistry, list_skills, load_skill_body, register_skill,
+)
+
+__all__ = [
+    "LazyToolRegistry", "ToolStub", "register_tool", "list_tools", "load_schema",
+    "SkillManifest", "SkillRegistry", "register_skill", "list_skills", "load_skill_body",
+]

--- a/agent/registry/lazy_schema.py
+++ b/agent/registry/lazy_schema.py
@@ -1,0 +1,85 @@
+"""On-demand tool JSON schema registry.
+
+At startup, only ``(name, description)`` pairs are registered. The full
+JSON schema is fetched the first time ``load_schema(name)`` is invoked
+and cached. See ``docs/perf/lazy-schemas.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Lock
+from typing import Callable, Dict, List, Mapping
+
+SchemaLoader = Callable[[], Mapping[str, object]]
+
+
+@dataclass(frozen=True)
+class ToolStub:
+    """Minimal tool entry kept in memory at startup."""
+
+    name: str
+    description: str
+
+
+class LazyToolRegistry:
+    """Registry of tool name -> stub + schema loader (cached on first load)."""
+
+    def __init__(self) -> None:
+        self._stubs: Dict[str, ToolStub] = {}
+        self._loaders: Dict[str, SchemaLoader] = {}
+        self._schemas: Dict[str, Mapping[str, object]] = {}
+        self._lock = Lock()
+
+    def register(
+        self, name: str, description: str, schema_loader: SchemaLoader
+    ) -> ToolStub:
+        if not name:
+            raise ValueError("tool name must be non-empty")
+        if not callable(schema_loader):
+            raise TypeError("schema_loader must be callable")
+        stub = ToolStub(name=name, description=description)
+        with self._lock:
+            self._stubs[name] = stub
+            self._loaders[name] = schema_loader
+            self._schemas.pop(name, None)
+        return stub
+
+    def list(self) -> List[ToolStub]:
+        with self._lock:
+            return list(self._stubs.values())
+
+    def load(self, name: str) -> Mapping[str, object]:
+        with self._lock:
+            cached = self._schemas.get(name)
+            if cached is not None:
+                return cached
+            loader = self._loaders.get(name)
+            if loader is None:
+                raise KeyError(f"tool not registered: {name}")
+        schema = loader()
+        if not isinstance(schema, Mapping):
+            raise TypeError(
+                f"schema loader for {name!r} must return Mapping, got {type(schema).__name__}"
+            )
+        with self._lock:
+            self._schemas[name] = schema
+        return schema
+
+    def stats(self) -> Mapping[str, int]:
+        with self._lock:
+            return {"registered": len(self._stubs), "loaded": len(self._schemas)}
+
+    def clear(self) -> None:
+        with self._lock:
+            self._stubs.clear()
+            self._loaders.clear()
+            self._schemas.clear()
+
+
+_default = LazyToolRegistry()
+
+register_tool = _default.register
+list_tools = _default.list
+load_schema = _default.load
+_reset_default_registry_for_tests = _default.clear

--- a/agent/registry/skill_meta.py
+++ b/agent/registry/skill_meta.py
@@ -1,0 +1,95 @@
+"""Compact skill manifests with lazy body loading.
+
+Default skill representation is ``SkillManifest(name, trigger,
+steps_summary)``. The full SKILL.md body is loaded on demand via
+:func:`load_skill_body`. See ``docs/perf/lazy-schemas.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Lock
+from typing import Callable, Dict, List
+
+BodyLoader = Callable[[], str]
+
+
+@dataclass(frozen=True)
+class SkillManifest:
+    """Minimal skill descriptor kept in memory."""
+
+    name: str
+    trigger: str
+    steps_summary: str
+
+
+class SkillRegistry:
+    """Registry of skill manifests + body loaders (body cached on first load)."""
+
+    def __init__(self) -> None:
+        self._manifests: Dict[str, SkillManifest] = {}
+        self._loaders: Dict[str, BodyLoader] = {}
+        self._bodies: Dict[str, str] = {}
+        self._lock = Lock()
+
+    def register(
+        self, name: str, trigger: str, steps_summary: str, body_loader: BodyLoader
+    ) -> SkillManifest:
+        if not name:
+            raise ValueError("skill name must be non-empty")
+        if not callable(body_loader):
+            raise TypeError("body_loader must be callable")
+        manifest = SkillManifest(name=name, trigger=trigger, steps_summary=steps_summary)
+        with self._lock:
+            self._manifests[name] = manifest
+            self._loaders[name] = body_loader
+            self._bodies.pop(name, None)
+        return manifest
+
+    def register_path(
+        self, name: str, trigger: str, steps_summary: str, body_path
+    ) -> SkillManifest:
+        path = Path(body_path)
+        return self.register(
+            name, trigger, steps_summary, lambda: path.read_text(encoding="utf-8")
+        )
+
+    def list(self) -> List[SkillManifest]:
+        with self._lock:
+            return list(self._manifests.values())
+
+    def load_body(self, name: str) -> str:
+        with self._lock:
+            cached = self._bodies.get(name)
+            if cached is not None:
+                return cached
+            loader = self._loaders.get(name)
+            if loader is None:
+                raise KeyError(f"skill not registered: {name}")
+        body = loader()
+        if not isinstance(body, str):
+            raise TypeError(
+                f"body loader for {name!r} must return str, got {type(body).__name__}"
+            )
+        with self._lock:
+            self._bodies[name] = body
+        return body
+
+    def stats(self) -> Dict[str, int]:
+        with self._lock:
+            return {"registered": len(self._manifests), "loaded": len(self._bodies)}
+
+    def clear(self) -> None:
+        with self._lock:
+            self._manifests.clear()
+            self._loaders.clear()
+            self._bodies.clear()
+
+
+_default = SkillRegistry()
+
+register_skill = _default.register
+list_skills = _default.list
+load_skill_body = _default.load_body
+_reset_default_registry_for_tests = _default.clear

--- a/docs/perf/lazy-schemas.md
+++ b/docs/perf/lazy-schemas.md
@@ -1,0 +1,46 @@
+# Lazy Tool Schemas & Skill Metadata
+
+## Motivation
+
+Tool JSON schemas and full SKILL.md bodies dominate the cold prompt.
+Hundreds of tools and dozens of skills get advertised even when a turn
+uses a handful. `agent/registry/` publishes only the lightweight surface
+at startup and loads the heavy payload on first use.
+
+## Components
+
+- `agent.registry.lazy_schema` — `ToolStub(name, description)` registry.
+  Full JSON schema produced by a `schema_loader` callable and cached on
+  the first call to `load_schema(name)`.
+- `agent.registry.skill_meta` — `SkillManifest(name, trigger,
+  steps_summary)` registry. Full SKILL.md body produced by a
+  `body_loader` (or via `register_path`) and cached on the first call
+  to `load_skill_body(name)`. Thread-safe; exposes `stats()` and `clear()`.
+
+## Usage
+
+```python
+from agent.registry import register_tool, list_tools, load_schema
+
+register_tool("search", "Search the web.",
+              lambda: {"type": "object",
+                       "properties": {"q": {"type": "string"}}})
+stubs = list_tools()           # [ToolStub("search", "Search the web.")]
+schema = load_schema("search") # full JSON, cached
+```
+
+Skills mirror the API via `register_skill` / `list_skills` /
+`load_skill_body`. For on-disk SKILL.md, use
+`SkillRegistry.register_path(name, trigger, summary, path)`.
+
+## Expected savings
+
+A stub is ~80-200 B; a full schema 0.6-6 KB. For 200 tools, the cold
+tool surface drops from ~600 KB to ~30 KB. Skill bodies typically weigh
+2-10 KB vs. <200 B for a manifest.
+
+## Notes
+
+- Loaders run outside the internal lock; concurrent readers are not blocked.
+- Re-registering a name invalidates the cached payload.
+- Loader exceptions propagate; no negative caching.

--- a/tests/registry/test_lazy_schema.py
+++ b/tests/registry/test_lazy_schema.py
@@ -1,0 +1,72 @@
+"""Unit tests for :mod:`agent.registry.lazy_schema`."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.registry.lazy_schema import LazyToolRegistry, ToolStub
+
+
+def _schema_factory(calls):
+    def _load():
+        calls.append(1)
+        return {"type": "object", "properties": {"q": {"type": "string"}}}
+
+    return _load
+
+
+def test_register_stores_only_stub():
+    reg = LazyToolRegistry()
+    calls = []
+    reg.register("search", "Search the web.", _schema_factory(calls))
+    assert reg.list() == [ToolStub("search", "Search the web.")]
+    assert calls == []
+    assert reg.stats() == {"registered": 1, "loaded": 0}
+
+
+def test_load_schema_invokes_loader_once():
+    reg = LazyToolRegistry()
+    calls = []
+    reg.register("search", "Search the web.", _schema_factory(calls))
+    assert reg.load("search") is reg.load("search")
+    assert calls == [1]
+    assert reg.stats() == {"registered": 1, "loaded": 1}
+
+
+def test_load_unknown_raises():
+    with pytest.raises(KeyError):
+        LazyToolRegistry().load("missing")
+
+
+def test_register_validates_inputs():
+    reg = LazyToolRegistry()
+    with pytest.raises(ValueError):
+        reg.register("", "x", lambda: {})
+    with pytest.raises(TypeError):
+        reg.register("ok", "x", "not-callable")  # type: ignore[arg-type]
+
+
+def test_loader_must_return_mapping():
+    reg = LazyToolRegistry()
+    reg.register("bad", "broken", lambda: "not a mapping")  # type: ignore[arg-type,return-value]
+    with pytest.raises(TypeError):
+        reg.load("bad")
+
+
+def test_register_overwrites_and_resets_cache():
+    reg = LazyToolRegistry()
+    reg.register("t", "v1", lambda: {"v": 1})
+    assert reg.load("t") == {"v": 1}
+    reg.register("t", "v2", lambda: {"v": 2})
+    assert reg.load("t") == {"v": 2}
+    assert reg.stats()["registered"] == 1
+
+
+def test_default_registry_helpers():
+    from agent.registry import lazy_schema as mod
+
+    mod._reset_default_registry_for_tests()
+    mod.register_tool("a", "alpha", lambda: {"k": "v"})
+    assert [t.name for t in mod.list_tools()] == ["a"]
+    assert mod.load_schema("a") == {"k": "v"}
+    mod._reset_default_registry_for_tests()

--- a/tests/registry/test_skill_meta.py
+++ b/tests/registry/test_skill_meta.py
@@ -1,0 +1,67 @@
+"""Unit tests for :mod:`agent.registry.skill_meta`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.registry.skill_meta import SkillManifest, SkillRegistry
+
+
+SAMPLE_BODY = "# Sample\n\n## Trigger\nX\n\n## Steps\n1. A\n2. B\n"
+
+
+def test_register_stores_only_manifest():
+    reg = SkillRegistry()
+    calls = []
+    reg.register("s", "trig", "summ", lambda: (calls.append(1), SAMPLE_BODY)[1])
+    assert reg.list() == [SkillManifest("s", "trig", "summ")]
+    assert calls == []
+    assert reg.stats() == {"registered": 1, "loaded": 0}
+
+
+def test_load_body_caches_first_call():
+    reg = SkillRegistry()
+    calls = []
+
+    def loader():
+        calls.append(1)
+        return SAMPLE_BODY
+
+    reg.register("s", "t", "s", loader)
+    assert reg.load_body("s") is reg.load_body("s")
+    assert calls == [1]
+
+
+def test_register_path_lazy_reads_file(tmp_path: Path):
+    body_path = tmp_path / "SKILL.md"
+    body_path.write_text(SAMPLE_BODY, encoding="utf-8")
+    reg = SkillRegistry()
+    reg.register_path("d", "t", "s", body_path)
+    assert reg.stats() == {"registered": 1, "loaded": 0}
+    assert reg.load_body("d") == SAMPLE_BODY
+    assert reg.stats() == {"registered": 1, "loaded": 1}
+
+
+def test_validation_errors():
+    reg = SkillRegistry()
+    with pytest.raises(ValueError):
+        reg.register("", "t", "s", lambda: "")
+    with pytest.raises(TypeError):
+        reg.register("x", "t", "s", "not-callable")  # type: ignore[arg-type]
+    reg.register("bad", "t", "s", lambda: 123)  # type: ignore[arg-type,return-value]
+    with pytest.raises(TypeError):
+        reg.load_body("bad")
+    with pytest.raises(KeyError):
+        reg.load_body("missing")
+
+
+def test_default_registry_helpers():
+    from agent.registry import skill_meta as mod
+
+    mod._reset_default_registry_for_tests()
+    mod.register_skill("s1", "t", "s", lambda: "body")
+    assert [s.name for s in mod.list_skills()] == ["s1"]
+    assert mod.load_skill_body("s1") == "body"
+    mod._reset_default_registry_for_tests()


### PR DESCRIPTION
Tracks #98 — previously closed without commits, reopened to deliver real implementation.

## Scope
Add on-demand tool schema and skill metadata minimization

## Status
Scaffold only. Implementation plan in `.plans/issue-98-add-on-demand-tool-schema-and-skill-metadata-minimization.md`. Will be expanded in follow-up commits until DoD is green.

Refs #98