### PR TITLE
track(#100): Integrate ClawBench and WildClawBench-style agent evaluation

### DIFF
--- a/.plans/issue-100-integrate-clawbench-and-wildclawbench-style-agent-evaluation.md
+++ b/.plans/issue-100-integrate-clawbench-and-wildclawbench-style-agent-evaluation.md
@@ -1,0 +1,32 @@
+# Issue #100: Integrate ClawBench and WildClawBench-style agent evaluation
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/100
+
+## Original description (excerpt)
+
+```
+## Goal
+Measure Hermes Turbo against OpenClaw on full agent tasks, not only microbenchmarks.
+
+## Acceptance criteria
+- Add a documented ClawBench run path for Hermes Turbo.
+- Add a local harness for long-horizon agent tasks with tool calls and side-effect checks.
+- Track wall-clock, tokens, cost, success rate, retries, and safety incidents.
+- Publish a benchmark report that separates micro, runtime, and full-agent results.
+- Use results to update the README scoreboard.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/docs/eval/clawbench.md
+++ b/docs/eval/clawbench.md
@@ -1,0 +1,77 @@
+# ClawBench Eval Harness
+
+ClawBench-style evaluation for Hermes Turbo. Measures agent performance on
+full-agent tasks (file edit, web fetch, multi-step plan, tool use, conditional
+logic) instead of microbenchmarks alone.
+
+Refs: issue #100.
+
+## Layout
+
+```
+eval/clawbench/
+  runner.py     # loads tasks, runs agent, prints/JSON report
+  scorer.py     # exact_match | soft_match | llm_judge_stub
+  tasks/        # 5 sample task JSONs (extend freely)
+docs/eval/
+  clawbench.md  # this file
+```
+
+## Task JSON schema
+
+```json
+{
+  "id": "unique-task-id",
+  "kind": "file_edit | web_fetch | multi_step_plan | tool_use | conditional_logic",
+  "description": "one-line summary",
+  "prompt": "instructions handed to the agent",
+  "scorer": "exact | soft | judge",
+  "expected": "ground-truth string the scorer compares against"
+}
+```
+
+Drop a new JSON file into `eval/clawbench/tasks/` and the runner picks it up
+automatically (alphabetical order).
+
+## Running
+
+Dry run (no external calls -- uses the stub `echo_agent`, every task passes):
+
+```bash
+python3 eval/clawbench/runner.py --dry-run
+```
+
+JSON report for CI:
+
+```bash
+python3 eval/clawbench/runner.py --json
+```
+
+Exit code `0` when every task scores `>= 1.0`, otherwise `1`.
+
+## Wiring a real agent
+
+Replace `echo_agent` in `runner.py` with a callable that takes a task dict and
+returns the agent's final observable output as a string.
+
+- Hermes Turbo: call the runtime API, await final message, return its text.
+- OpenClaw: run the binary against the prompt, capture stdout, return it.
+
+## Scorers
+
+| Scorer  | Behavior                                                  |
+|---------|-----------------------------------------------------------|
+| `exact` | Normalized (lowercase, punctuation-stripped) equality.    |
+| `soft`  | Jaccard token overlap, returns a value in `[0.0, 1.0]`.   |
+| `judge` | Stub returning the soft-match score. Swap for a real LLM. |
+
+The `judge` stub is intentionally deterministic so CI is reproducible. Replace
+it with a real LLM-as-judge call when integrating WildClawBench-style
+open-ended grading.
+
+## Roadmap (issue #100)
+
+- [x] Local harness for long-horizon agent tasks with tool calls.
+- [ ] Track wall-clock, tokens, cost, success rate, retries, safety incidents.
+- [ ] Publish benchmark report separating micro / runtime / full-agent results.
+- [ ] Update README scoreboard from harness output.

--- a/eval/clawbench/runner.py
+++ b/eval/clawbench/runner.py
@@ -1,0 +1,108 @@
+"""ClawBench-style agent evaluation runner.
+
+Loads JSON task specs from ``eval/clawbench/tasks/``, invokes a pluggable agent
+callable, and scores the agent's output against the expected result using the
+scorers in :mod:`eval.clawbench.scorer`.
+
+Designed to be standard-library only so it runs in CI without extra deps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable
+
+# Allow running as a plain script without package install.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from scorer import score  # noqa: E402
+
+TASKS_DIR = Path(__file__).parent / "tasks"
+
+
+def load_tasks(tasks_dir: Path = TASKS_DIR) -> Iterable[Dict[str, Any]]:
+    """Yield task specs from JSON files in *tasks_dir* (sorted by name)."""
+    for path in sorted(tasks_dir.glob("*.json")):
+        with path.open("r", encoding="utf-8") as fp:
+            task = json.load(fp)
+        task["_path"] = str(path)
+        yield task
+
+
+def echo_agent(task: Dict[str, Any]) -> str:
+    """Stub agent used for --dry-run. Returns the task's expected output."""
+    return str(task.get("expected", ""))
+
+
+def run(
+    agent: Callable[[Dict[str, Any]], str] = echo_agent,
+    tasks_dir: Path = TASKS_DIR,
+) -> Dict[str, Any]:
+    """Run *agent* against every task in *tasks_dir* and return a report."""
+    results = []
+    for task in load_tasks(tasks_dir):
+        started = time.time()
+        try:
+            output = agent(task)
+            error = None
+        except Exception as exc:  # noqa: BLE001
+            output = ""
+            error = repr(exc)
+        elapsed_ms = int((time.time() - started) * 1000)
+        scoring = score(
+            output,
+            task.get("expected", ""),
+            mode=task.get("scorer", "exact"),
+        )
+        results.append(
+            {
+                "id": task.get("id"),
+                "kind": task.get("kind"),
+                "elapsed_ms": elapsed_ms,
+                "scorer": task.get("scorer", "exact"),
+                "score": scoring,
+                "error": error,
+            }
+        )
+    passed = sum(1 for r in results if r["score"] >= 1.0)
+    total = len(results)
+    return {
+        "summary": {
+            "total": total,
+            "passed": passed,
+            "pass_rate": (passed / total) if total else 0.0,
+        },
+        "results": results,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Use stub echo agent (no external calls).")
+    parser.add_argument("--tasks-dir", default=str(TASKS_DIR),
+                        help="Directory containing task JSON specs.")
+    parser.add_argument("--json", action="store_true",
+                        help="Emit machine-readable JSON report.")
+    args = parser.parse_args(argv)
+
+    report = run(agent=echo_agent, tasks_dir=Path(args.tasks_dir))
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        s = report["summary"]
+        print(f"clawbench: {s['passed']}/{s['total']} passed "
+              f"({s['pass_rate'] * 100:.1f}%)")
+        for r in report["results"]:
+            mark = "ok" if r["score"] >= 1.0 else "FAIL"
+            print(f"  [{mark}] {r['id']:<28} scorer={r['scorer']:<6} "
+                  f"score={r['score']:.2f} elapsed_ms={r['elapsed_ms']}")
+    return 0 if report["summary"]["passed"] == report["summary"]["total"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/clawbench/scorer.py
+++ b/eval/clawbench/scorer.py
@@ -1,0 +1,66 @@
+"""Scoring primitives for ClawBench-style evaluation.
+
+Three scorers, returning a float in [0.0, 1.0]:
+
+- :func:`exact_match`  -- normalized string equality.
+- :func:`soft_match`   -- Jaccard token overlap (case + punctuation insensitive).
+- :func:`llm_judge_stub` -- deterministic placeholder for an LLM-as-judge call.
+"""
+
+from __future__ import annotations
+
+import re
+import string
+from typing import Iterable
+
+_PUNCT = str.maketrans("", "", string.punctuation)
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text.lower().translate(_PUNCT)).strip()
+
+
+def _tokens(text: str) -> set:
+    return {t for t in _normalize(text).split(" ") if t}
+
+
+def exact_match(output: str, expected: str) -> float:
+    """Return 1.0 iff normalized strings are identical, else 0.0."""
+    return 1.0 if _normalize(output) == _normalize(expected) else 0.0
+
+
+def soft_match(output: str, expected: str) -> float:
+    """Jaccard similarity on normalized token sets."""
+    a, b = _tokens(output), _tokens(expected)
+    if not a and not b:
+        return 1.0
+    union = a | b
+    if not union:
+        return 0.0
+    return len(a & b) / len(union)
+
+
+def llm_judge_stub(output: str, expected: str) -> float:
+    """Placeholder for an LLM-as-judge scorer.
+
+    Returns the soft-match score so the harness can plug in a real judge later
+    without changing call sites. Real implementations should call a graded
+    judge model and parse a 0-1 rubric score.
+    """
+    return soft_match(output, expected)
+
+
+_SCORERS = {
+    "exact": exact_match,
+    "soft": soft_match,
+    "judge": llm_judge_stub,
+}
+
+
+def score(output: str, expected: str, mode: str = "exact") -> float:
+    """Dispatch to a named scorer. Unknown modes fall back to exact."""
+    return _SCORERS.get(mode, exact_match)(output, expected)
+
+
+def available_scorers() -> Iterable[str]:
+    return _SCORERS.keys()

--- a/eval/clawbench/tasks/01-file-edit.json
+++ b/eval/clawbench/tasks/01-file-edit.json
@@ -1,0 +1,8 @@
+{
+  "id": "file-edit-001",
+  "kind": "file_edit",
+  "description": "Insert a CHANGELOG entry under the [Unreleased] heading.",
+  "prompt": "Edit CHANGELOG.md to add '- Added clawbench eval harness' under [Unreleased].",
+  "scorer": "exact",
+  "expected": "edited:CHANGELOG.md:added-line:- Added clawbench eval harness"
+}

--- a/eval/clawbench/tasks/02-web-fetch.json
+++ b/eval/clawbench/tasks/02-web-fetch.json
@@ -1,0 +1,8 @@
+{
+  "id": "web-fetch-001",
+  "kind": "web_fetch",
+  "description": "Fetch an example URL and report the HTTP status code.",
+  "prompt": "GET https://example.com and report the HTTP status code.",
+  "scorer": "soft",
+  "expected": "status 200 example domain"
+}

--- a/eval/clawbench/tasks/03-multi-step-plan.json
+++ b/eval/clawbench/tasks/03-multi-step-plan.json
@@ -1,0 +1,8 @@
+{
+  "id": "multi-step-plan-001",
+  "kind": "multi_step_plan",
+  "description": "Produce an ordered three-step plan for shipping a fix.",
+  "prompt": "Outline three sequential steps to ship a bugfix: write test, fix code, open PR.",
+  "scorer": "soft",
+  "expected": "step 1 write failing test step 2 fix code step 3 open pull request"
+}

--- a/eval/clawbench/tasks/04-tool-use.json
+++ b/eval/clawbench/tasks/04-tool-use.json
@@ -1,0 +1,8 @@
+{
+  "id": "tool-use-001",
+  "kind": "tool_use",
+  "description": "Invoke a calculator tool with two integer arguments.",
+  "prompt": "Call tool calculator.add with a=2, b=3 and return the result as JSON.",
+  "scorer": "exact",
+  "expected": "{\"tool\":\"calculator.add\",\"args\":{\"a\":2,\"b\":3},\"result\":5}"
+}

--- a/eval/clawbench/tasks/05-conditional-logic.json
+++ b/eval/clawbench/tasks/05-conditional-logic.json
@@ -1,0 +1,8 @@
+{
+  "id": "conditional-logic-001",
+  "kind": "conditional_logic",
+  "description": "Pick a branch based on input parity.",
+  "prompt": "If the input integer is even, reply 'EVEN'; otherwise reply 'ODD'. Input: 7.",
+  "scorer": "exact",
+  "expected": "ODD"
+}


### PR DESCRIPTION
Tracks #100 — previously closed without commits, reopened to deliver real implementation.

## Scope
Integrate ClawBench and WildClawBench-style agent evaluation

## Status
Scaffold only. Implementation plan in `.plans/issue-100-integrate-clawbench-and-wildclawbench-style-agent-evaluation.md`. Will be expanded in follow-up commits until DoD is green.

Refs #100