### PR TITLE
track(#101): Optimize output-token usage with concise response contracts

### DIFF
--- a/.plans/issue-101-optimize-output-token-usage-with-concise-response-contracts.md
+++ b/.plans/issue-101-optimize-output-token-usage-with-concise-response-contracts.md
@@ -1,0 +1,32 @@
+# Issue #101: Optimize output-token usage with concise response contracts
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/101
+
+## Original description (excerpt)
+
+```
+## Goal
+Reduce latency and cost by generating fewer output tokens in autonomous loops, status updates, and tool summaries.
+
+## Acceptance criteria
+- Add concise response contracts for loop status, tool summaries, PR updates, and issue comments.
+- Use structured fields instead of verbose prose for machine-facing loops.
+- Preserve human-readable summaries for final reports.
+- Track output-token savings separately from input-token savings.
+- Add tests for summary completeness.
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/agent/contracts/__init__.py
+++ b/agent/contracts/__init__.py
@@ -1,0 +1,17 @@
+"""Response contracts for output-token-efficient agent replies (issue #101)."""
+
+from agent.contracts.concise_response import (
+    ConciseContractError,
+    Diagnostic,
+    TerseAnswer,
+    ToolCall,
+    enforce_budget,
+)
+
+__all__ = [
+    "ConciseContractError",
+    "Diagnostic",
+    "TerseAnswer",
+    "ToolCall",
+    "enforce_budget",
+]

--- a/agent/contracts/concise_response.py
+++ b/agent/contracts/concise_response.py
@@ -1,0 +1,140 @@
+"""Concise response contracts (issue #101).
+
+Reduces output-token usage by forcing the model into structured,
+budget-capped responses. Each contract declares a `max_chars` budget;
+any field that exceeds the budget is truncated by `enforce_budget`,
+with a single trailing ellipsis to signal that truncation kicked in.
+
+Contracts:
+    * TerseAnswer  - short prose reply with optional citations.
+    * ToolCall     - request to invoke a tool with named arguments.
+    * Diagnostic   - structured error/warning/info signal.
+
+The intent is "narrow, predictable, cheap" - not a general DTO layer.
+Validators run at construction time so contracts cannot escape the
+process with over-budget strings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Dict, List, Tuple
+
+ELLIPSIS = "..."
+
+
+class ConciseContractError(ValueError):
+    """Raised when a contract is constructed with invalid input."""
+
+
+def enforce_budget(value: str, max_chars: int) -> str:
+    """Truncate `value` to at most `max_chars` chars, suffixing ELLIPSIS.
+
+    Raises ConciseContractError when `max_chars` is smaller than the
+    ellipsis length - we never want a budget that cannot signal
+    truncation.
+    """
+
+    if max_chars < len(ELLIPSIS):
+        raise ConciseContractError(
+            f"max_chars={max_chars} is smaller than ellipsis length"
+        )
+    if not isinstance(value, str):
+        raise ConciseContractError(f"expected str, got {type(value).__name__}")
+    if len(value) <= max_chars:
+        return value
+    cutoff = max_chars - len(ELLIPSIS)
+    return value[:cutoff] + ELLIPSIS
+
+
+def _coerce_str(name: str, value: Any) -> str:
+    if not isinstance(value, str):
+        raise ConciseContractError(f"{name} must be str, got {type(value).__name__}")
+    return value
+
+
+@dataclass
+class TerseAnswer:
+    """Short prose answer. Default budget tuned for chat replies."""
+
+    MAX_CHARS: ClassVar[int] = 600
+    MAX_CITATIONS: ClassVar[int] = 4
+    MAX_CITATION_CHARS: ClassVar[int] = 120
+
+    text: str
+    citations: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.text = enforce_budget(_coerce_str("text", self.text), self.MAX_CHARS)
+        if len(self.citations) > self.MAX_CITATIONS:
+            self.citations = self.citations[: self.MAX_CITATIONS]
+        self.citations = [
+            enforce_budget(_coerce_str("citation", c), self.MAX_CITATION_CHARS)
+            for c in self.citations
+        ]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"text": self.text, "citations": list(self.citations)}
+
+
+@dataclass
+class ToolCall:
+    """Structured tool invocation. Args are stringified key/value pairs."""
+
+    MAX_NAME_CHARS: ClassVar[int] = 64
+    MAX_ARGS: ClassVar[int] = 8
+    MAX_ARG_KEY_CHARS: ClassVar[int] = 32
+    MAX_ARG_VALUE_CHARS: ClassVar[int] = 240
+
+    name: str
+    args: List[Tuple[str, str]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.name = enforce_budget(_coerce_str("name", self.name), self.MAX_NAME_CHARS)
+        if not self.name:
+            raise ConciseContractError("tool name must be non-empty")
+        if len(self.args) > self.MAX_ARGS:
+            self.args = self.args[: self.MAX_ARGS]
+        capped: List[Tuple[str, str]] = []
+        for pair in self.args:
+            if not (isinstance(pair, tuple) and len(pair) == 2):
+                raise ConciseContractError("each arg must be a (key, value) tuple")
+            key = enforce_budget(_coerce_str("arg key", pair[0]), self.MAX_ARG_KEY_CHARS)
+            val = enforce_budget(
+                _coerce_str("arg value", pair[1]), self.MAX_ARG_VALUE_CHARS
+            )
+            capped.append((key, val))
+        self.args = capped
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"name": self.name, "args": [list(a) for a in self.args]}
+
+
+@dataclass
+class Diagnostic:
+    """Structured info / warning / error signal."""
+
+    LEVELS: ClassVar[Tuple[str, ...]] = ("info", "warning", "error")
+    MAX_CODE_CHARS: ClassVar[int] = 48
+    MAX_MESSAGE_CHARS: ClassVar[int] = 280
+
+    level: str
+    code: str
+    message: str
+
+    def __post_init__(self) -> None:
+        level = _coerce_str("level", self.level).lower()
+        if level not in self.LEVELS:
+            raise ConciseContractError(
+                f"level must be one of {self.LEVELS}, got {self.level!r}"
+            )
+        self.level = level
+        self.code = enforce_budget(_coerce_str("code", self.code), self.MAX_CODE_CHARS)
+        if not self.code:
+            raise ConciseContractError("code must be non-empty")
+        self.message = enforce_budget(
+            _coerce_str("message", self.message), self.MAX_MESSAGE_CHARS
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"level": self.level, "code": self.code, "message": self.message}

--- a/docs/perf/concise-contracts.md
+++ b/docs/perf/concise-contracts.md
@@ -1,0 +1,38 @@
+# Concise Response Contracts
+
+Ref: issue #101. Goal: cut output-token spend by forcing the agent into
+narrow, budget-capped reply shapes.
+
+## Contracts
+
+Defined in `agent/contracts/concise_response.py`:
+
+| Contract     | Purpose                         | Budget                                                |
+|--------------|---------------------------------|-------------------------------------------------------|
+| TerseAnswer  | Default chat reply              | text<=600; <=4 citations of 120 chars                 |
+| ToolCall     | Structured tool invocation      | name<=64; <=8 args (key<=32, value<=240)              |
+| Diagnostic   | Info / warning / error signal   | code<=48; message<=280; level in {info,warning,error} |
+
+All over-budget strings are truncated with a trailing `...` ellipsis by
+`enforce_budget`. The validator runs at construction time, so an
+instance is guaranteed within budget once it exists.
+
+## How the model is told
+
+`prompts/contracts/concise.md` is injected into the system prompt of
+agent loops that should emit machine-parseable output. It describes
+each JSON shape, the budgets, and five rules (no extra fields, no code
+fences, rewrite-don't-rely-on-truncate, prefer `Diagnostic` over a
+chatty refusal, one contract per turn).
+
+## Wiring
+
+The contracts and prompt fragment ship together. Loader/parser work
+(injecting the fragment and decoding model output into the dataclasses)
+lands in a separate follow-up PR to keep this change reviewable.
+
+## Tests
+
+`tests/contracts/test_concise_response.py` asserts truncation at each
+budget boundary, ellipsis suffix, rejection of bad input, and stable
+`to_dict()` shapes. Run: `python -m unittest tests.contracts.test_concise_response`.

--- a/prompts/contracts/concise.md
+++ b/prompts/contracts/concise.md
@@ -1,0 +1,43 @@
+<!-- System-prompt fragment: concise response contracts (issue #101) -->
+
+You MUST respond using one of the structured contracts below. Pick the
+narrowest contract that fits. Stay inside the budget - the runtime
+hard-truncates fields that exceed it.
+
+### TerseAnswer (default chat reply)
+
+```json
+{"type": "TerseAnswer",
+ "text": "<answer, <= 600 chars>",
+ "citations": ["<src, <= 120 chars>", "..."]}
+```
+
+`citations` up to 4 items, optional.
+
+### ToolCall
+
+```json
+{"type": "ToolCall",
+ "name": "<tool name, <= 64 chars>",
+ "args": [["<key, <=32>", "<value, <=240>"]]}
+```
+
+`name` required, non-empty. `args` up to 8 pairs.
+
+### Diagnostic
+
+```json
+{"type": "Diagnostic",
+ "level": "info | warning | error",
+ "code": "<code, <= 48 chars>",
+ "message": "<message, <= 280 chars>"}
+```
+
+## Rules
+
+1. Never invent fields outside the contract.
+2. Never wrap the JSON in code fences when emitting machine output.
+3. If your reply would exceed a budget, REWRITE it shorter - do not
+   rely on truncation to silence you.
+4. Prefer `Diagnostic` over a chatty refusal in `TerseAnswer`.
+5. Output exactly one contract per turn.

--- a/tests/contracts/test_concise_response.py
+++ b/tests/contracts/test_concise_response.py
@@ -1,0 +1,111 @@
+"""Tests for agent/contracts/concise_response.py (issue #101)."""
+
+from __future__ import annotations
+
+import unittest
+
+from agent.contracts.concise_response import (
+    ConciseContractError,
+    Diagnostic,
+    TerseAnswer,
+    ToolCall,
+    enforce_budget,
+)
+
+
+class EnforceBudgetTests(unittest.TestCase):
+    def test_short_value_is_unchanged(self) -> None:
+        self.assertEqual(enforce_budget("hi", 10), "hi")
+        self.assertEqual(enforce_budget("abcde", 5), "abcde")
+
+    def test_long_value_is_truncated_with_ellipsis(self) -> None:
+        result = enforce_budget("x" * 50, 10)
+        self.assertEqual(len(result), 10)
+        self.assertEqual(result, "xxxxxxx...")
+
+    def test_rejects_bad_input(self) -> None:
+        with self.assertRaises(ConciseContractError):
+            enforce_budget("any", 2)
+        with self.assertRaises(ConciseContractError):
+            enforce_budget(123, 10)  # type: ignore[arg-type]
+
+
+class TerseAnswerTests(unittest.TestCase):
+    def test_text_truncates_when_over_budget(self) -> None:
+        answer = TerseAnswer(text="a" * (TerseAnswer.MAX_CHARS + 200))
+        self.assertEqual(len(answer.text), TerseAnswer.MAX_CHARS)
+        self.assertTrue(answer.text.endswith("..."))
+
+    def test_short_text_is_unchanged(self) -> None:
+        self.assertEqual(TerseAnswer(text="short").text, "short")
+
+    def test_citations_capped_and_truncated(self) -> None:
+        big = "c" * (TerseAnswer.MAX_CITATION_CHARS + 50)
+        cits = [big] * (TerseAnswer.MAX_CITATIONS + 3)
+        answer = TerseAnswer(text="t", citations=cits)
+        self.assertEqual(len(answer.citations), TerseAnswer.MAX_CITATIONS)
+        for c in answer.citations:
+            self.assertEqual(len(c), TerseAnswer.MAX_CITATION_CHARS)
+            self.assertTrue(c.endswith("..."))
+
+    def test_to_dict(self) -> None:
+        self.assertEqual(
+            TerseAnswer(text="hello", citations=["a"]).to_dict(),
+            {"text": "hello", "citations": ["a"]},
+        )
+
+
+class ToolCallTests(unittest.TestCase):
+    def test_name_truncates(self) -> None:
+        call = ToolCall(name="n" * (ToolCall.MAX_NAME_CHARS + 10))
+        self.assertEqual(len(call.name), ToolCall.MAX_NAME_CHARS)
+        self.assertTrue(call.name.endswith("..."))
+
+    def test_empty_name_rejected(self) -> None:
+        with self.assertRaises(ConciseContractError):
+            ToolCall(name="")
+
+    def test_args_capped_and_truncated(self) -> None:
+        big = "v" * (ToolCall.MAX_ARG_VALUE_CHARS + 80)
+        pairs = [(f"k{i}", big) for i in range(ToolCall.MAX_ARGS + 5)]
+        call = ToolCall(name="t", args=pairs)
+        self.assertEqual(len(call.args), ToolCall.MAX_ARGS)
+        self.assertEqual(len(call.args[0][1]), ToolCall.MAX_ARG_VALUE_CHARS)
+        self.assertTrue(call.args[0][1].endswith("..."))
+
+    def test_arg_must_be_pair(self) -> None:
+        with self.assertRaises(ConciseContractError):
+            ToolCall(name="t", args=[("only",)])  # type: ignore[list-item]
+
+    def test_to_dict(self) -> None:
+        self.assertEqual(
+            ToolCall(name="search", args=[("q", "isa")]).to_dict(),
+            {"name": "search", "args": [["q", "isa"]]},
+        )
+
+
+class DiagnosticTests(unittest.TestCase):
+    def test_level_normalised_and_validated(self) -> None:
+        self.assertEqual(Diagnostic("ERROR", "E", "m").level, "error")
+        with self.assertRaises(ConciseContractError):
+            Diagnostic(level="fatal", code="E", message="m")
+
+    def test_empty_code_rejected(self) -> None:
+        with self.assertRaises(ConciseContractError):
+            Diagnostic(level="info", code="", message="m")
+
+    def test_message_truncates(self) -> None:
+        big = "m" * (Diagnostic.MAX_MESSAGE_CHARS + 100)
+        diag = Diagnostic(level="warning", code="W", message=big)
+        self.assertEqual(len(diag.message), Diagnostic.MAX_MESSAGE_CHARS)
+        self.assertTrue(diag.message.endswith("..."))
+
+    def test_to_dict(self) -> None:
+        self.assertEqual(
+            Diagnostic(level="info", code="OK", message="all good").to_dict(),
+            {"level": "info", "code": "OK", "message": "all good"},
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Tracks #101 — previously closed without commits, reopened to deliver real implementation.

## Scope
Optimize output-token usage with concise response contracts

## Status
Scaffold only. Implementation plan in `.plans/issue-101-optimize-output-token-usage-with-concise-response-contracts.md`. Will be expanded in follow-up commits until DoD is green.

Refs #101