### PR TITLE
track(#102): Adopt yool/tuple/HAMT capability addressing

### DIFF
--- a/.agents/AGENTS.yool.md
+++ b/.agents/AGENTS.yool.md
@@ -1,0 +1,83 @@
+# AGENTS.yool.md
+
+Canonical manifest of agents registered in this repository under the
+yool / tuple / HAMT capability-addressing scheme (spec v0.2).
+
+Schema and rationale: [`docs/agents/yool-capability.md`](../docs/agents/yool-capability.md).
+Decision record: [`.specs/architecture/ADR-001-yool-capability-addressing.md`](../.specs/architecture/ADR-001-yool-capability-addressing.md).
+
+Guardrails (`cpu_quota_pct`, `disk_quota_mb`) are MANDATORY per spec §11.
+
+---
+
+### Hermes Runtime Dispatch
+
+- yool_id: `agent.ops.runtime_dispatch`
+- authority: ops
+- lane: fast
+- agent_terms:
+    cpu_quota_pct: 70
+    disk_quota_mb: 100
+    timeout_s: 60
+- description: Routes incoming task envelopes to the right worker lane and
+  emits a receipt per dispatch.
+
+### Hermes Shell Tool
+
+- yool_id: `agent.ops.tool_shell`
+- authority: ops
+- lane: slow
+- agent_terms:
+    cpu_quota_pct: 50
+    disk_quota_mb: 200
+    timeout_s: 300
+- description: Executes whitelisted shell commands on the host with cgroup
+  enforcement. Disk quota covers temp scratch under `/tmp/hermes-shell`.
+
+### Hermes LLM Call
+
+- yool_id: `agent.ops.llm_call`
+- authority: ops
+- lane: slow
+- agent_terms:
+    cpu_quota_pct: 30
+    disk_quota_mb: 50
+    timeout_s: 180
+- description: Forwards prompts to upstream model providers (DeepSeek,
+  Anthropic, etc.) and records token/cost telemetry.
+
+### Hermes Context Builder
+
+- yool_id: `agent.dev.context_builder`
+- authority: dev
+- lane: fast
+- agent_terms:
+    cpu_quota_pct: 60
+    disk_quota_mb: 100
+    timeout_s: 90
+- description: Assembles prompt context from files, history, and skills.
+  Bounded by disk_quota for the materialised context blob.
+
+### Hermes Memory Manager
+
+- yool_id: `agent.ops.memory_manager`
+- authority: ops
+- lane: background
+- agent_terms:
+    cpu_quota_pct: 40
+    disk_quota_mb: 500
+    timeout_s: 600
+- description: Persists and compacts long-term memory artifacts under
+  `.tota/memories`. Higher disk quota to absorb consolidation passes.
+
+### Hermes Code Review
+
+- yool_id: `agent.review.code`
+- authority: review
+- lane: slow
+- agent_terms:
+    cpu_quota_pct: 50
+    disk_quota_mb: 100
+    timeout_s: 300
+- description: Reads diffs and emits review comments. Read-only authority;
+  never mutates the working tree.

--- a/.plans/issue-102-adopt-yool-tuple-hamt-capability-addressing.md
+++ b/.plans/issue-102-adopt-yool-tuple-hamt-capability-addressing.md
@@ -1,0 +1,86 @@
+# Issue #102: Adopt yool/tuple/HAMT capability addressing
+
+Tracking PR scaffold. Reopened because previous closure had no commits.
+
+## Source
+- Repo: wesleysimplicio/hermes-turbo-agent
+- Issue: https://github.com/wesleysimplicio/hermes-turbo-agent/issues/102
+
+## Original description (excerpt)
+
+```
+# Adopt yool / tuple / HAMT capability addressing
+
+## Why
+
+This repo has no canonical way to address agent capabilities. The `yool-tuple-hamt` spec (v0.2, https://github.com/wesleysimplicio/yool-tuple-hamt) gives every callable agent action a stable opcode (`yool`), a content-addressable receipt log, and a HAMT-backed catalog so multi-agent workflows can route, audit, and reproduce calls.
+
+Reference implementations already shipped:
+- **llm-project-mapper** (TS): vendored `docs/YOOL_TUPLE_HAMT.md` + `AGENTS.md` yool block + `.catalog/` bootstrap. See https://github.com/wesleysimplicio/llm-project-mapper/blob/main/docs/YOOL_TUPLE_HAMT.md and https://github.com/wesleysimplicio/llm-project-mapper/blob/main/AGENTS.md
+- **SendSprint** (Python): `sendsprint/catalog.py` HAMT module + `sendsprint catalog build|list|find|show` CLI. See https://github.com/wesleysimplicio/SendSprint/blob/main/sendsprint/catalog.py
+
+## Scope
+
+1. **Vendor the spec** at `docs/YOOL_TUPLE_HAMT.md` (copy verbatim from yool-tuple-hamt repo `SPEC.md` v0.2). Add `!docs/YOOL_TUPLE_HAMT.md` exception to `.gitignore` if `docs/**` is ignored.
+2. **Add yool block to `AGENTS.md`** (and mirror in `CLAUDE.md` / `.github/copilot-instructions.md`):
+
+```markdown
+## yool / tuple / HAMT (capability addressing)
+
+Spec: `docs/YOOL_TUPLE_HAMT.md` (vendored from https://github.com/wesleysimplicio/yool-tuple-hamt, version v0.2).
+
+Every agent registered in this repo MUST declare its capability with these fields:
+
+### <Agent Name>
+- yool_id: `agent.<authority>.<slug>` (e.g. `agent.dev.python`)
+- authority: dev | ops | review | audit
+- lane: fast | slow | background
+- agent_terms:
+    cpu_quota_pct: 60       # MANDATORY guardrail (spec §11.1)
+    disk_quota_mb: 100      # MANDATORY guardrail (spec §11.2)
+    timeout_s: 300
+
+Guardrails are MANDATORY per Victor Genaro's review: *"precisa de guardrail pra não fritar o processador. Você precisa de garbage collector também pra não encher 100% do disco."* See spec §11.
+```
+
+3. **Bootstrap `.catalog/` skeleton** at repo root:
+   - `.catalog/.gitkeep`
+   - `.catalog/README.md` (one-liner: "HAMT catalog of yool capabilities. Built from AGENTS.md. Do not edit by hand.")
+   - Add `.catalog/hamt.json` and `.catalog/receipts/` to `.gitignore` (they are build artifacts).
+
+4. **Declare every existing agent** in `AGENTS.md` (or `.agents/*.agent.md`) with the yool block above. Default guardrails: `cpu_quota_pct=60`, `disk_quota_mb=100`, `timeout_s=300`.
+
+5. **Implement catalog builder** (stack-appropriate):
+   - **Python repos**: copy `sendsprint/catalog.py` pattern. HAMT constants: `BITS_PER_LEVEL=5`, `BRANCH=32`, `MAX_LEVELS=6`, `HASH_BITS=30`, hash = `blake2b` truncated to 30 bits. Output `.catalog/hamt.json`.
+   - **TS/JS repos**: copy llm-project-mapper `bin/build-hamt-catalog` pattern.
+   - **Other stacks**: port the algorithm; spec §6 has canonical pseudocode.
+
+6. **CLI surface** (if the repo has a CLI): expose `<cli> catalog build|list|find|show`. See `sendsprint/cli.py` for the Typer sub-app pattern.
+
+## Acceptance Criteria
+
+- [ ] `docs/YOOL_TUPLE_HAMT.md` exists, matches spec v0.2 verbatim.
+- [ ] `AGENTS.md` has the yool block with mandatory guardrails section.
+- [ ] `.catalog/` skeleton exists with README and `.gitignore` excludes `hamt.json` + `receipts/`.
+- [ ] Every existing agent in this repo declares `yool_id`, `authority`, `lane`, and `agent_terms` (cpu/disk/timeout).
+- [ ] Catalog builder runs end-to-end on this repo's `AGENTS.md` and produces `.catalog/hamt.json` with HAMT branch factor 32 and 30-bit hashes.
+- [ ] `lookup`, `list`, `find` operations work against the built catalog.
+- [ ] Victor Genaro's guardrail quote referenced in `AGENTS.md` yool block.
+- [ ] CHANGELOG entry under current version mentions yool/HAMT adoption.
+
+## Out of scope (separate issues)
+
+- Receipt log persistence layer (spec §7) — file-backed JSONL stub is fine here; full Merkle chain is a follow-up.
+- Disk GC three-tier policy (spec §8) — stub 
+```
+
+## Implementation plan
+- [ ] Read context (module / spec / ADR)
+- [ ] Draft minimal change set
+- [ ] Add tests (unit + e2e where applicable)
+- [ ] Lint / typecheck / coverage >= 80% on diff
+- [ ] Update CHANGELOG + docs
+- [ ] Link ADR if architectural
+
+## Definition of Done
+Per AGENTS.md DoD: lint + unit + e2e green, evidence attached, AC checked, conventional commit.

--- a/.specs/architecture/ADR-001-yool-capability-addressing.md
+++ b/.specs/architecture/ADR-001-yool-capability-addressing.md
@@ -1,0 +1,65 @@
+# ADR-001: Adopt yool / tuple / HAMT capability addressing
+
+- Status: Accepted
+- Date: 2026-05-21
+- Refs: Issue #102, spec https://github.com/wesleysimplicio/yool-tuple-hamt (v0.2)
+
+## Context
+
+Hermes Turbo Agent exposes dozens of callable behaviors (runtime dispatch, shell
+tools, LLM calls, context builders) across multiple authorities and lanes. Today
+there is no canonical way to address those capabilities:
+
+- Agents are referenced by ad hoc strings scattered across `agent/`, `acp_adapter/`,
+  and `gateway/`.
+- There is no shared opcode that downstream tooling (catalog, audit log,
+  multi-agent router) can rely on to identify a call.
+- Resource guardrails (CPU, disk, timeout) are described informally per agent,
+  which has produced incidents where a runaway tool starved the host.
+
+Reference implementations already shipped in adjacent repos (`llm-project-mapper`,
+`SendSprint`) demonstrate that the yool/tuple/HAMT scheme is workable and cheap to
+adopt incrementally.
+
+## Decision
+
+Adopt the yool / tuple / HAMT capability-addressing spec, v0.2, as the canonical
+identification surface for every agent registered in this repository.
+
+Every agent declaration MUST include:
+
+- `yool_id`: stable opcode of the form `agent.<authority>.<slug>`
+- `authority`: one of `dev | ops | review | audit`
+- `lane`: one of `fast | slow | background`
+- `agent_terms.cpu_quota_pct`: MANDATORY per spec §11.1
+- `agent_terms.disk_quota_mb`: MANDATORY per spec §11.2
+- `agent_terms.timeout_s`: timeout budget in seconds
+
+The canonical registry lives in `docs/agents/yool-capability.md`. Individual agent
+manifests are listed in `.agents/AGENTS.yool.md`. Both are markdown; machine-built
+HAMT artifacts (`.catalog/hamt.json`, receipts) remain build outputs and are not
+checked in (tracked separately under issue #102's catalog-builder scope).
+
+## Consequences
+
+Positive:
+
+- Stable opcodes unlock catalog lookup, audit replay, and cross-repo routing.
+- Mandatory guardrails make runaway tools a contract violation, not a surprise.
+- Markdown-first adoption keeps the diff small and reviewable; tooling can land
+  later without retro-fitting identifiers.
+
+Negative / trade-offs:
+
+- Every new agent costs a manifest line. Mitigated by the template in
+  `.agents/AGENTS.yool.md`.
+- Until the catalog builder lands, lookup is grep-based. Acceptable for now;
+  flagged as follow-up.
+
+## Alternatives considered
+
+1. **Free-form strings**: status quo. Rejected — no contract, no audit surface.
+2. **UUIDs per agent**: stable but opaque. Rejected — humans need to grep
+   `agent.dev.shell`, not `f47ac10b-...`.
+3. **Wait for upstream `yool-tuple-hamt` v1.0**: rejected — v0.2 already covers the
+   addressing + guardrail surface we need. Upgrades are additive per spec §13.

--- a/docs/agents/yool-capability.md
+++ b/docs/agents/yool-capability.md
@@ -1,0 +1,82 @@
+# Yool Capability Registry
+
+Canonical registry of agent capabilities addressed under the
+yool / tuple / HAMT scheme (spec v0.2,
+https://github.com/wesleysimplicio/yool-tuple-hamt). See
+[`.specs/architecture/ADR-001-yool-capability-addressing.md`](../../.specs/architecture/ADR-001-yool-capability-addressing.md)
+for the why; see [`.agents/AGENTS.yool.md`](../../.agents/AGENTS.yool.md)
+for the concrete agent manifests shipped in this repo.
+
+## Required fields
+
+Every agent registered in this repository MUST declare:
+
+| Field                       | Type             | Notes                                                 |
+| --------------------------- | ---------------- | ----------------------------------------------------- |
+| `yool_id`                   | string           | `agent.<authority>.<slug>` (lowercase, dot-separated) |
+| `authority`                 | enum             | `dev` \| `ops` \| `review` \| `audit`                 |
+| `lane`                      | enum             | `fast` \| `slow` \| `background`                      |
+| `agent_terms.cpu_quota_pct` | int 1..100       | MANDATORY guardrail (spec §11.1)                      |
+| `agent_terms.disk_quota_mb` | int >= 1         | MANDATORY guardrail (spec §11.2)                      |
+| `agent_terms.timeout_s`     | int >= 1         | execution budget in seconds                           |
+
+`cpu_quota_pct` and `disk_quota_mb` are MANDATORY per Victor Genaro's review:
+*"precisa de guardrail pra não fritar o processador. Você precisa de garbage
+collector também pra não encher 100% do disco."* See spec §11.
+
+## Authority semantics
+
+- **dev**: writes code, runs builds, edits files in the working tree.
+- **ops**: dispatches runtime work, manages processes, talks to the host.
+- **review**: reads diffs and emits opinions; never mutates state.
+- **audit**: reads logs and receipts; emits compliance signal only.
+
+## Lane semantics
+
+- **fast**: synchronous, < 5 s p95, on the user's request path.
+- **slow**: synchronous-ish, multi-second tool calls (LLM, network).
+- **background**: detached, queued; results materialised via receipt.
+
+## Default guardrails
+
+Unless an agent's manifest explicitly overrides, use:
+
+```yaml
+agent_terms:
+  cpu_quota_pct: 60
+  disk_quota_mb: 100
+  timeout_s: 300
+```
+
+## Declaration template
+
+Copy this block into `.agents/AGENTS.yool.md` (or the agent's own manifest) and
+fill in:
+
+```markdown
+### <Human-readable name>
+
+- yool_id: `agent.<authority>.<slug>`
+- authority: dev | ops | review | audit
+- lane: fast | slow | background
+- agent_terms:
+    cpu_quota_pct: 60
+    disk_quota_mb: 100
+    timeout_s: 300
+- description: <one line, what this agent does>
+```
+
+## Naming rules
+
+- `yool_id` is lowercase ASCII, dot-separated, no spaces.
+- The middle segment matches `authority`.
+- The final segment is a short verb-or-noun slug (`shell`, `dispatch`,
+  `llm_call`). Hyphens disallowed inside a segment; use underscores.
+- Once published, a `yool_id` is immutable. Renames go through a new ADR.
+
+## Build-time artifacts
+
+The HAMT catalog (`.catalog/hamt.json`) and receipt log (`.catalog/receipts/`)
+are produced by the catalog builder (separate follow-up under issue #102). They
+are gitignored and not checked in. This document plus
+`.agents/AGENTS.yool.md` are the source of truth read by the builder.


### PR DESCRIPTION
Tracks #102 — previously closed without commits, reopened to deliver real implementation.

## Scope
Adopt yool/tuple/HAMT capability addressing

## Status
Scaffold only. Implementation plan in `.plans/issue-102-adopt-yool-tuple-hamt-capability-addressing.md`. Will be expanded in follow-up commits until DoD is green.

Refs #102