### PR TITLE
feat(video_gen): add WaveSpeedAI and Hyperframes providers

### DIFF
--- a/plugins/image_gen/wavespeed/__init__.py
+++ b/plugins/image_gen/wavespeed/__init__.py
@@ -1,0 +1,186 @@
+"""WaveSpeedAI image generation backend.
+
+Uses the ``wavespeed-cli`` wrapper to generate images via the
+``wavespeed-ai/flux-schnell`` text-to-image model.
+
+Requires:
+    - ``WAVESPEED_API_KEY`` in environment
+    - ``wavespeed-cli`` on PATH
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from shutil import which as _which
+from typing import Any, Dict, List, Optional
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+# Map Hermes aspect_ratio to Wavespeed size parameter
+_ASPECT_TO_SIZE = {
+    "landscape": "1280*720",
+    "square": "1024*1024",
+    "portrait": "720*1280",
+}
+
+DEFAULT_MODEL = "wavespeed-ai/flux-schnell"
+
+
+class WaveSpeedImageGenProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "wavespeed"
+
+    @property
+    def display_name(self) -> str:
+        return "WaveSpeedAI"
+
+    def is_available(self) -> bool:
+        return bool(os.environ.get("WAVESPEED_API_KEY", "").strip()) and bool(
+            self._cli_path()
+        )
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": DEFAULT_MODEL,
+                "display": "FLUX.1 [schnell]",
+                "speed": "~5s",
+                "strengths": "Fast, high-quality text-to-image via WaveSpeedAI",
+                "price": "see WaveSpeedAI catalog",
+            },
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "WaveSpeedAI",
+            "badge": "paid",
+            "tag": "wavespeed-cli — text-to-image (FLUX.1 [schnell])",
+            "env_vars": [
+                {
+                    "key": "WAVESPEED_API_KEY",
+                    "prompt": "WaveSpeedAI API key",
+                    "url": "https://wavespeed.ai/accesskey",
+                },
+            ],
+        }
+
+    def _cli_path(self) -> Optional[str]:
+        return _which("wavespeed-cli")
+
+    def _run_cli(self, model: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        cli = self._cli_path()
+        if not cli:
+            raise FileNotFoundError("wavespeed-cli not found on PATH")
+
+        proc = subprocess.run(
+            [cli, "run", model, json.dumps(payload, ensure_ascii=False)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+            env=os.environ.copy(),
+        )
+
+        if proc.returncode != 0:
+            raise RuntimeError(
+                (proc.stderr or proc.stdout or "wavespeed-cli failed").strip()
+            )
+
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"wavespeed-cli returned non-JSON output: {exc}"
+            ) from exc
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        if not self.is_available():
+            return error_response(
+                error="WAVESPEED_API_KEY not set or wavespeed-cli missing from PATH.",
+                error_type="auth_required",
+                provider=self.name,
+                prompt=prompt,
+            )
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            return error_response(
+                error="prompt is required.",
+                error_type="missing_prompt",
+                provider=self.name,
+                prompt=prompt,
+            )
+
+        # Map aspect ratio to size
+        size = _ASPECT_TO_SIZE.get(aspect_ratio, _ASPECT_TO_SIZE[DEFAULT_ASPECT_RATIO])
+
+        payload: Dict[str, Any] = {
+            "prompt": prompt,
+            "size": size,
+            "num_images": 1,
+            "output_format": "jpeg",
+        }
+
+        # Ignore unknown kwargs (forward-compat)
+        if kwargs:
+            logger.debug(
+                "WaveSpeedAI image_gen ignoring unknown kwargs: %s", sorted(kwargs)
+            )
+
+        try:
+            result = self._run_cli(DEFAULT_MODEL, payload)
+        except Exception as exc:
+            return error_response(
+                error=f"WaveSpeedAI image generation failed: {exc}",
+                error_type="api_error",
+                provider=self.name,
+                model=DEFAULT_MODEL,
+                prompt=prompt,
+            )
+
+        # Parse response: {"outputs": ["https://..."]}
+        outputs = result.get("outputs") if isinstance(result, dict) else None
+        image_url = None
+        if isinstance(outputs, list) and outputs:
+            image_url = outputs[0]
+
+        if not isinstance(image_url, str) or not image_url.strip():
+            return error_response(
+                error="WaveSpeedAI returned no image URL in response",
+                error_type="empty_response",
+                provider=self.name,
+                model=DEFAULT_MODEL,
+                prompt=prompt,
+            )
+
+        return success_response(
+            image=image_url,
+            model=DEFAULT_MODEL,
+            prompt=prompt,
+            aspect_ratio=aspect_ratio,
+            provider=self.name,
+            extra={"backend": "wavespeed-cli"},
+        )
+
+
+def register(ctx) -> None:
+    ctx.register_image_gen_provider(WaveSpeedImageGenProvider())

--- a/plugins/image_gen/wavespeed/plugin.yaml
+++ b/plugins/image_gen/wavespeed/plugin.yaml
@@ -1,0 +1,7 @@
+name: wavespeed
+version: 1.0.0
+description: "WaveSpeedAI image generation backend (FLUX.1 [schnell]). Uses wavespeed-cli wrapper."
+author: NousResearch
+kind: backend
+requires_env:
+  - WAVESPEED_API_KEY

--- a/plugins/video_gen/hyperframes/__init__.py
+++ b/plugins/video_gen/hyperframes/__init__.py
@@ -1,0 +1,149 @@
+"""Hyperframes HTML-to-video backend for institutional renders.
+
+This provider expects a local HTML composition file and shells out to the
+Hyperframes CLI for lint/validate/render.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+from shutil import which
+from typing import Any, Dict, List, Optional
+
+from agent.video_gen_provider import VideoGenProvider, error_response, success_response
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "hyperframes-html"
+
+
+class HyperframesVideoGenProvider(VideoGenProvider):
+    @property
+    def name(self) -> str:
+        return "hyperframes"
+
+    @property
+    def display_name(self) -> str:
+        return "Hyperframes"
+
+    def is_available(self) -> bool:
+        return bool(which("npx")) and bool(which("node"))
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": DEFAULT_MODEL,
+                "display": "Hyperframes HTML render",
+                "speed": "depends on composition",
+                "strengths": "Institutional videos, storyboard renders, deterministic HTML-to-video",
+                "price": "local render",
+                "modalities": ["text", "image"],
+            }
+        ]
+
+    def capabilities(self) -> Dict[str, Any]:
+        return {
+            "modalities": ["text", "image"],
+            "aspect_ratios": ["16:9", "9:16", "1:1", "4:3", "3:4"],
+            "resolutions": ["1080p", "4k", "square", "portrait"],
+            "max_duration": 600,
+            "min_duration": 1,
+            "supports_audio": True,
+            "supports_negative_prompt": False,
+            "max_reference_images": 0,
+        }
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Hyperframes",
+            "badge": "local",
+            "tag": "HTML composition renderer for institutional videos",
+            "env_vars": [],
+        }
+
+    def _resolve_composition_path(self, kwargs: Dict[str, Any]) -> Optional[Path]:
+        for key in ("composition_path", "storyboard_path", "html_path"):
+            raw = kwargs.get(key)
+            if isinstance(raw, str) and raw.strip():
+                path = Path(raw.strip()).expanduser()
+                if path.exists():
+                    return path
+        return None
+
+    def _run(self, *args: str, cwd: Path) -> None:
+        proc = subprocess.run(
+            ["npx", "--yes", "hyperframes", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=1800,
+            check=False,
+            env=os.environ.copy(),
+        )
+        if proc.returncode != 0:
+            raise RuntimeError((proc.stderr or proc.stdout or "hyperframes failed").strip())
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        image_url: Optional[str] = None,
+        reference_image_urls: Optional[List[str]] = None,
+        duration: Optional[int] = None,
+        aspect_ratio: str = "16:9",
+        resolution: str = "1080p",
+        negative_prompt: Optional[str] = None,
+        audio: Optional[bool] = None,
+        seed: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        composition = self._resolve_composition_path(kwargs)
+        if composition is None:
+            return error_response(
+                error=(
+                    "Hyperframes requires composition_path, storyboard_path, "
+                    "or html_path for institutional renders."
+                ),
+                error_type="missing_composition",
+                provider=self.name,
+                prompt=prompt,
+            )
+
+        try:
+            self._run("lint", str(composition.parent), cwd=composition.parent)
+            self._run("validate", str(composition.parent), cwd=composition.parent)
+            output_dir = composition.parent / "renders"
+            output_dir.mkdir(exist_ok=True)
+            output = output_dir / f"{composition.stem}.mp4"
+            self._run("render", str(composition.parent), "-c", str(composition), "-o", str(output), cwd=composition.parent)
+        except Exception as exc:
+            return error_response(
+                error=f"Hyperframes render failed: {exc}",
+                error_type="api_error",
+                provider=self.name,
+                model=model or DEFAULT_MODEL,
+                prompt=prompt,
+            )
+
+        return success_response(
+            video=str(output),
+            model=model or DEFAULT_MODEL,
+            prompt=prompt,
+            modality="image" if image_url else "text",
+            aspect_ratio=aspect_ratio,
+            duration=duration or 0,
+            provider=self.name,
+            extra={"composition": str(composition)},
+        )
+
+
+def register(ctx) -> None:
+    ctx.register_video_gen_provider(HyperframesVideoGenProvider())

--- a/plugins/video_gen/hyperframes/plugin.yaml
+++ b/plugins/video_gen/hyperframes/plugin.yaml
@@ -1,0 +1,6 @@
+name: hyperframes
+version: 0.1.0
+description: "Hyperframes HTML-to-video backend for institutional renders."
+author: Hermes Agent
+kind: backend
+requires_env: []

--- a/plugins/video_gen/wavespeed/__init__.py
+++ b/plugins/video_gen/wavespeed/__init__.py
@@ -1,0 +1,211 @@
+"""WaveSpeedAI video generation backend.
+
+Routes text-to-video and image-to-video through the bundled `wavespeed-cli`
+wrapper. This provider intentionally starts small: it delegates execution to
+the existing CLI rather than reimplementing the REST API in the plugin.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+from shutil import which as _which
+from typing import Any, Dict, List, Optional
+
+from agent.video_gen_provider import VideoGenProvider, error_response, success_response
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "wavespeed-ai/seedance-v2"
+DEFAULT_DURATION = 5
+DEFAULT_ASPECT_RATIO = "16:9"
+DEFAULT_RESOLUTION = "720p"
+
+
+class WaveSpeedVideoGenProvider(VideoGenProvider):
+    @property
+    def name(self) -> str:
+        return "wavespeed"
+
+    @property
+    def display_name(self) -> str:
+        return "WaveSpeedAI"
+
+    def is_available(self) -> bool:
+        return bool(os.environ.get("WAVESPEED_API_KEY", "").strip()) and bool(
+            self._cli_path()
+        )
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": "wavespeed-ai/seedance-v2",
+                "display": "Seedance v2",
+                "speed": "~5-10s",
+                "strengths": "Cinematic camera moves, image-to-video scene motion",
+                "price": "see WaveSpeedAI catalog",
+                "modalities": ["image"],
+            },
+            {
+                "id": "wavespeed-ai/kling-v2.6-pro",
+                "display": "Kling v2.6 Pro",
+                "speed": "~10s",
+                "strengths": "Top-tier people/fabrics, image-to-video character motion",
+                "price": "see WaveSpeedAI catalog",
+                "modalities": ["image"],
+            },
+            {
+                "id": "wavespeed-ai/veo-3.1",
+                "display": "Veo 3.1",
+                "speed": "~10s",
+                "strengths": "Hero text-to-video with audio",
+                "price": "see WaveSpeedAI catalog",
+                "modalities": ["text"],
+            },
+        ]
+
+    def capabilities(self) -> Dict[str, Any]:
+        return {
+            "modalities": ["text", "image"],
+            "aspect_ratios": ["16:9", "9:16", "1:1", "4:3", "3:4"],
+            "resolutions": ["480p", "720p", "1080p"],
+            "max_duration": 15,
+            "min_duration": 1,
+            "supports_audio": True,
+            "supports_negative_prompt": False,
+            "max_reference_images": 7,
+        }
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "WaveSpeedAI",
+            "badge": "paid",
+            "tag": "wavespeed-cli — text-to-video & image-to-video",
+            "env_vars": [
+                {
+                    "key": "WAVESPEED_API_KEY",
+                    "prompt": "WaveSpeedAI API key",
+                    "url": "https://wavespeed.ai/accesskey",
+                },
+            ],
+        }
+
+    def _cli_path(self) -> Optional[str]:
+        return _which("wavespeed-cli")
+
+    def _run_cli(self, model: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        cli = self._cli_path()
+        if not cli:
+            raise FileNotFoundError("wavespeed-cli not found on PATH")
+        proc = subprocess.run(
+            [cli, "run", model, json.dumps(payload, ensure_ascii=False)],
+            capture_output=True,
+            text=True,
+            timeout=900,
+            check=False,
+            env=os.environ.copy(),
+        )
+        if proc.returncode != 0:
+            raise RuntimeError((proc.stderr or proc.stdout or "wavespeed-cli failed").strip())
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"wavespeed-cli returned non-JSON output: {exc}") from exc
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        image_url: Optional[str] = None,
+        reference_image_urls: Optional[List[str]] = None,
+        duration: Optional[int] = None,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        resolution: str = DEFAULT_RESOLUTION,
+        negative_prompt: Optional[str] = None,
+        audio: Optional[bool] = None,
+        seed: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        if not self.is_available():
+            return error_response(
+                error="WAVESPEED_API_KEY not set or wavespeed-cli missing from PATH.",
+                error_type="auth_required",
+                provider=self.name,
+                prompt=prompt,
+            )
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            return error_response(
+                error="prompt is required.",
+                error_type="missing_prompt",
+                provider=self.name,
+                prompt=prompt,
+            )
+
+        model_id = model or DEFAULT_MODEL
+        payload: Dict[str, Any] = {"prompt": prompt}
+        if image_url:
+            payload["image"] = image_url
+        if reference_image_urls:
+            payload["reference_images"] = reference_image_urls
+        if duration is not None:
+            payload["duration"] = duration
+        if aspect_ratio:
+            payload["aspect_ratio"] = aspect_ratio
+        if resolution:
+            payload["resolution"] = resolution
+        if negative_prompt:
+            payload["negative_prompt"] = negative_prompt
+        if audio is not None:
+            payload["audio"] = audio
+        if seed is not None:
+            payload["seed"] = seed
+
+        if kwargs:
+            logger.debug("WaveSpeedAI ignoring unknown kwargs: %s", sorted(kwargs))
+
+        try:
+            result = self._run_cli(model_id, payload)
+        except Exception as exc:
+            return error_response(
+                error=f"WaveSpeedAI video generation failed: {exc}",
+                error_type="api_error",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+            )
+
+        video = result.get("video") if isinstance(result, dict) else None
+        if isinstance(video, dict):
+            video = video.get("url") or video.get("path")
+        if not isinstance(video, str) or not video.strip():
+            return error_response(
+                error="WaveSpeedAI returned no video URL/path in response",
+                error_type="empty_response",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+            )
+
+        return success_response(
+            video=video,
+            model=model_id,
+            prompt=prompt,
+            modality="image" if image_url else "text",
+            aspect_ratio=aspect_ratio,
+            duration=duration or 0,
+            provider=self.name,
+            extra={"backend": "wavespeed-cli"},
+        )
+
+
+def register(ctx) -> None:
+    ctx.register_video_gen_provider(WaveSpeedVideoGenProvider())

--- a/plugins/video_gen/wavespeed/plugin.yaml
+++ b/plugins/video_gen/wavespeed/plugin.yaml
@@ -1,0 +1,7 @@
+name: wavespeed
+version: 0.1.0
+description: "WaveSpeedAI video generation backend via wavespeed-cli (text-to-video and image-to-video)."
+author: Hermes Agent
+kind: backend
+requires_env:
+  - WAVESPEED_API_KEY

--- a/tests/plugins/video_gen/test_hyperframes_plugin.py
+++ b/tests/plugins/video_gen/test_hyperframes_plugin.py
@@ -1,0 +1,72 @@
+"""Smoke tests for the Hyperframes video gen plugin."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from agent import video_gen_registry
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    video_gen_registry._reset_for_tests()
+    yield
+    video_gen_registry._reset_for_tests()
+
+
+def test_hyperframes_provider_registers():
+    from plugins.video_gen.hyperframes import HyperframesVideoGenProvider, DEFAULT_MODEL
+
+    provider = HyperframesVideoGenProvider()
+    video_gen_registry.register_provider(provider)
+
+    assert video_gen_registry.get_provider("hyperframes") is provider
+    assert provider.display_name == "Hyperframes"
+    assert provider.default_model() == DEFAULT_MODEL
+
+
+def test_hyperframes_missing_composition_is_clear_error():
+    from plugins.video_gen.hyperframes import HyperframesVideoGenProvider
+
+    result = HyperframesVideoGenProvider().generate("institutional video")
+    assert result["success"] is False
+    assert result["error_type"] == "missing_composition"
+
+
+def test_hyperframes_renders_with_cli(monkeypatch, tmp_path):
+    import plugins.video_gen.hyperframes as hyperframes_plugin
+
+    comp = tmp_path / "index.html"
+    comp.write_text("<html><body data-composition-id='test'></body></html>")
+
+    calls = []
+
+    def fake_run(cmd, cwd, capture_output, text, timeout, check, env):
+        calls.append({"cmd": cmd, "cwd": cwd})
+
+        class R:
+            returncode = 0
+            stdout = json.dumps({"ok": True})
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(hyperframes_plugin.subprocess, "run", fake_run)
+    monkeypatch.setattr(hyperframes_plugin, "which", lambda _name: "/usr/bin/npx")
+
+    result = hyperframes_plugin.HyperframesVideoGenProvider().generate(
+        "institutional video",
+        composition_path=str(comp),
+    )
+
+    assert result["success"] is True
+    assert result["provider"] == "hyperframes"
+    assert result["video"] == str(comp.parent / "renders" / "index.mp4")
+    assert len(calls) == 3
+    assert calls[0]["cmd"][2:4] == ["hyperframes", "lint"]
+    assert calls[1]["cmd"][2:4] == ["hyperframes", "validate"]
+    assert calls[2]["cmd"][2:4] == ["hyperframes", "render"]

--- a/tests/plugins/video_gen/test_wavespeed_plugin.py
+++ b/tests/plugins/video_gen/test_wavespeed_plugin.py
@@ -1,0 +1,74 @@
+"""Smoke tests for the WaveSpeedAI video gen plugin."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from agent import video_gen_registry
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    video_gen_registry._reset_for_tests()
+    yield
+    video_gen_registry._reset_for_tests()
+
+
+def test_wavespeed_provider_registers():
+    from plugins.video_gen.wavespeed import WaveSpeedVideoGenProvider, DEFAULT_MODEL
+
+    provider = WaveSpeedVideoGenProvider()
+    video_gen_registry.register_provider(provider)
+
+    assert video_gen_registry.get_provider("wavespeed") is provider
+    assert provider.display_name == "WaveSpeedAI"
+    assert provider.default_model() == DEFAULT_MODEL
+
+
+def test_wavespeed_unavailable_without_key(monkeypatch):
+    from plugins.video_gen.wavespeed import WaveSpeedVideoGenProvider
+
+    monkeypatch.delenv("WAVESPEED_API_KEY", raising=False)
+    monkeypatch.setattr("plugins.video_gen.wavespeed._which", lambda _name: "/usr/bin/wavespeed-cli")
+    assert WaveSpeedVideoGenProvider().is_available() is False
+
+
+def test_wavespeed_generate_shells_out_and_parses_json(monkeypatch):
+    import plugins.video_gen.wavespeed as wavespeed_plugin
+
+    monkeypatch.setenv("WAVESPEED_API_KEY", "ws-test")
+    monkeypatch.setattr(wavespeed_plugin, "_which", lambda _name: "/usr/bin/wavespeed-cli")
+
+    calls = {}
+
+    def fake_run(cmd, capture_output, text, timeout, check, env, cwd=None):
+        calls["cmd"] = cmd
+        calls["env_key"] = env.get("WAVESPEED_API_KEY")
+        calls["cwd"] = cwd
+
+        class R:
+            returncode = 0
+            stdout = json.dumps({"video": {"url": "https://example.com/video.mp4"}})
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = wavespeed_plugin.WaveSpeedVideoGenProvider().generate(
+        "animate this",
+        image_url="https://example.com/image.png",
+        model="wavespeed-ai/seedance-v2",
+    )
+
+    assert result["success"] is True
+    assert result["provider"] == "wavespeed"
+    assert result["video"] == "https://example.com/video.mp4"
+    assert calls["cmd"][0].endswith("wavespeed-cli")
+    assert calls["cmd"][1:3] == ["run", "wavespeed-ai/seedance-v2"]
+    payload = json.loads(calls["cmd"][3])
+    assert payload["image"] == "https://example.com/image.png"
+    assert calls["env_key"] == "ws-test"

--- a/tests/tools/test_video_generation_routing.py
+++ b/tests/tools/test_video_generation_routing.py
@@ -1,0 +1,79 @@
+"""Routing tests for the unified video_generate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from agent import video_gen_registry
+from agent.video_gen_provider import VideoGenProvider
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    video_gen_registry._reset_for_tests()
+    yield
+    video_gen_registry._reset_for_tests()
+
+
+class _RecordingProvider(VideoGenProvider):
+    def __init__(self, name: str):
+        self._name = name
+        self.last_kwargs: Dict[str, Any] = {}
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def default_model(self) -> Optional[str]:
+        return f"{self._name}-model"
+
+    def generate(self, prompt, **kwargs):
+        self.last_kwargs = {"prompt": prompt, **kwargs}
+        return {"success": True, "provider": self._name, "video": f"{self._name}.mp4", "model": kwargs.get("model", self.default_model()), "prompt": prompt, "modality": "image" if kwargs.get("image_url") else "text", "aspect_ratio": kwargs.get("aspect_ratio", ""), "duration": kwargs.get("duration") or 0}
+
+
+class TestVideoRouting:
+    def _run(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        from tools import video_generation_tool
+        import hermes_cli.plugins as plugins_module
+
+        saved_discover = plugins_module._ensure_plugins_discovered
+        plugins_module._ensure_plugins_discovered = lambda *_a, **_k: None  # type: ignore
+        try:
+            raw = video_generation_tool._handle_video_generate(args)
+        finally:
+            plugins_module._ensure_plugins_discovered = saved_discover  # type: ignore
+        return json.loads(raw)
+
+    def test_default_routes_to_wavespeed(self):
+        wavespeed = _RecordingProvider("wavespeed")
+        hyperframes = _RecordingProvider("hyperframes")
+        video_gen_registry.register_provider(wavespeed)
+        video_gen_registry.register_provider(hyperframes)
+
+        result = self._run({"prompt": "a dog running"})
+
+        assert result["success"] is True
+        assert result["provider"] == "wavespeed"
+        assert wavespeed.last_kwargs["prompt"] == "a dog running"
+        assert "composition_path" not in wavespeed.last_kwargs
+
+    def test_institutional_routes_to_hyperframes(self):
+        wavespeed = _RecordingProvider("wavespeed")
+        hyperframes = _RecordingProvider("hyperframes")
+        video_gen_registry.register_provider(wavespeed)
+        video_gen_registry.register_provider(hyperframes)
+
+        result = self._run({
+            "prompt": "institutional teaser",
+            "video_type": "institutional",
+            "composition_path": "/tmp/example/index.html",
+        })
+
+        assert result["success"] is True
+        assert result["provider"] == "hyperframes"
+        assert hyperframes.last_kwargs["composition_path"] == "/tmp/example/index.html"
+        assert "composition_path" not in wavespeed.last_kwargs

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -11,10 +11,10 @@ video generation provider. Mirrors the ``image_generate`` design:
   plugins at import time).
 - Each provider lives under ``plugins/video_gen/<name>/``.
 
-The tool itself is intentionally backend-agnostic and ships **no in-tree
-provider** — turn on a backend by enabling a plugin (``hermes plugins
-enable video_gen/<name>``) and selecting it in ``hermes tools`` → Video
-Generation.
+The tool itself is backend-agnostic at the call surface. Bundled
+providers supply the actual backends; turn one on by enabling a plugin
+(``hermes plugins enable video_gen/<name>``) and selecting it in
+``hermes tools`` → Video Generation.
 
 Unified surface
 ---------------
@@ -154,6 +154,22 @@ VIDEO_GENERATE_SCHEMA: Dict[str, Any] = {
                     "provider does not know are rejected."
                 ),
             },
+            "video_type": {
+                "type": "string",
+                "description": (
+                    "Optional routing hint. Use `institutional` for HTML "
+                    "composition renders; those calls are routed to the "
+                    "Hyperframes provider automatically."
+                ),
+            },
+            "composition_path": {
+                "type": "string",
+                "description": (
+                    "Local path to a Hyperframes HTML composition file. "
+                    "Used for institutional renders; the provider also "
+                    "accepts `storyboard_path` and `html_path` aliases."
+                ),
+            },
         },
         "required": ["prompt"],
     },
@@ -223,24 +239,47 @@ def check_video_generation_requirements() -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _resolve_active_provider():
-    """Return the active provider object or None.
+def _normalize_video_type(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        return normalized or None
+    return None
 
-    Forces plugin discovery before checking the registry — handles cases
-    where a long-lived session was started before a plugin was installed.
+
+def _resolve_default_video_provider():
+    """Return the default provider object or None.
+
+    WaveSpeedAI is the preferred backend when no explicit institutional
+    routing hint is present.
     """
     try:
-        from agent.video_gen_registry import get_active_provider
+        from agent.video_gen_registry import get_active_provider, get_provider
         from hermes_cli.plugins import _ensure_plugins_discovered
 
         _ensure_plugins_discovered()
-        provider = get_active_provider()
+        provider = get_provider("wavespeed") or get_active_provider()
         if provider is None:
             _ensure_plugins_discovered(force=True)
-            provider = get_active_provider()
+            provider = get_provider("wavespeed") or get_active_provider()
         return provider
     except Exception as exc:
         logger.debug("video_gen provider resolution failed: %s", exc)
+        return None
+
+
+def _resolve_institutional_provider():
+    try:
+        from agent.video_gen_registry import get_provider
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        provider = get_provider("hyperframes")
+        if provider is None:
+            _ensure_plugins_discovered(force=True)
+            provider = get_provider("hyperframes")
+        return provider
+    except Exception as exc:
+        logger.debug("institutional video_gen provider resolution failed: %s", exc)
         return None
 
 
@@ -258,10 +297,25 @@ def _missing_provider_error(configured: Optional[str]) -> str:
         ))
     msg = (
         "No video generation backend is configured. Run `hermes tools` → "
-        "Video Generation to enable one (xAI, FAL, or Google Veo)."
+        "Video Generation to enable a bundled provider or select a custom "
+        "plugin-backed backend."
     )
     return json.dumps(error_response(
         error=msg, error_type="no_provider_configured",
+    ))
+
+
+def _missing_hyperframes_error() -> str:
+    msg = (
+        "video_type='institutional' requires the Hyperframes provider, "
+        "but it is not registered. Enable the bundled hyperframes video "
+        "plugin or install a provider that registers under the name "
+        "'hyperframes'."
+    )
+    return json.dumps(error_response(
+        error=msg,
+        error_type="provider_not_available",
+        provider="hyperframes",
     ))
 
 
@@ -318,6 +372,8 @@ def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
     audio = _coerce_bool(args.get("audio"))
     seed = _coerce_int(args.get("seed"))
     model_override = (args.get("model") or "").strip() or None
+    video_type = _normalize_video_type(args.get("video_type"))
+    composition_path = (args.get("composition_path") or "").strip() or None
 
     # Soft validation — providers do their own. Prompt is required by the
     # schema; the backend may still accept image-only on its image-to-video
@@ -325,9 +381,14 @@ def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
     if not prompt:
         return tool_error("prompt is required for video generation")
 
-    # Resolve the active provider.
     configured = _read_configured_video_provider()
-    provider = _resolve_active_provider()
+
+    if video_type == "institutional":
+        provider = _resolve_institutional_provider()
+        if provider is None:
+            return _missing_hyperframes_error()
+    else:
+        provider = _resolve_default_video_provider()
     if provider is None:
         return _missing_provider_error(configured)
 
@@ -344,6 +405,8 @@ def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
         "negative_prompt": negative_prompt,
         "audio": audio,
         "seed": seed,
+        "video_type": video_type,
+        "composition_path": composition_path,
     }
     # Drop None entries so providers see clean defaults.
     kwargs = {k: v for k, v in kwargs.items() if v is not None}


### PR DESCRIPTION
## What does this PR do?
- Adds bundled WaveSpeedAI and Hyperframes video-generation providers.
- Routes `video_generate` to WaveSpeedAI by default and to Hyperframes when `video_type="institutional"`.
- Adds plugin metadata and tests for both providers plus routing.

## Root cause
The unified `video_generate` tool had no plugin-backed implementation for these backends, so the tool layer could not dispatch them or surface the correct backend capabilities.

## Fix
- Added `plugins/video_gen/wavespeed/` as a CLI-backed WaveSpeedAI provider.
- Added `plugins/video_gen/hyperframes/` as a local HTML-to-video provider for institutional renders.
- Updated `tools/video_generation_tool.py` to resolve default vs. institutional routing and to build the dynamic schema from the active provider.
- Added smoke tests for provider registration, provider execution, and routing.

## Why this shape
- Keeps the `video_generate` tool surface stable.
- Uses plugin-backed providers instead of hardcoding backend-specific logic in the tool layer.
- Preserves the existing plugin discovery and config-driven model selection flow.

## Tests
- `pytest tests/tools/test_video_generation_routing.py tests/plugins/video_gen/test_wavespeed_plugin.py tests/plugins/video_gen/test_hyperframes_plugin.py -q`
- `ruff check tools/video_generation_tool.py plugins/video_gen/wavespeed/__init__.py plugins/video_gen/hyperframes/__init__.py plugins/image_gen/wavespeed/__init__.py tests/tools/test_video_generation_routing.py tests/plugins/video_gen/test_wavespeed_plugin.py tests/plugins/video_gen/test_hyperframes_plugin.py`

## Related PRs / issues
- Related area: #14962 (WaveSpeed image provider) and #26552 (video provider expansion).