### PR TITLE
feat(prompt): prepare LLM calls with simplicio-prompt

### DIFF
--- a/agent/simplicio_prompt.py
+++ b/agent/simplicio_prompt.py
@@ -1,0 +1,60 @@
+"""Optional simplicio-prompt message preparation."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+MARKER = "<!-- simplicio-prompt:hermes-turbo -->"
+_TRUE = {"1", "true", "yes", "on"}
+
+_TEXT = (
+    "Use simplicio-prompt before answering. Treat the request as an "
+    "addressable yool, identify the deliverable and checks internally, "
+    "then return one concrete verified result."
+)
+_BATCH_TEXT = (
+    "Use simplicio-prompt batch mode for parallel work. Split independent "
+    "yool tuples, keep bounded lanes, merge receipts, and return one result."
+)
+
+
+def _enabled() -> bool:
+    raw = os.environ.get("HERMES_SIMPLICIO_PROMPT") or os.environ.get("SIMPLICIO_PROMPT")
+    if raw is None:
+        raw = os.environ.get("YOOL_TUPLE_FULL_RUNTIME")
+    return str(raw or "").strip().lower() in _TRUE
+
+
+def _block() -> str:
+    batch = str(os.environ.get("YOOL_TUPLE_FULL_RUNTIME") or "").strip().lower() in _TRUE
+    text = _BATCH_TEXT if batch else _TEXT
+    return f"{MARKER}\n# simplicio-prompt\n\n{text}"
+
+
+def _has_marker(content: Any) -> bool:
+    if isinstance(content, str):
+        return MARKER in content
+    if isinstance(content, list):
+        return any(isinstance(item, dict) and MARKER in str(item.get("text") or item.get("content") or "") for item in content)
+    return False
+
+
+def apply_simplicio_prompt(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    if not _enabled() or not isinstance(messages, list):
+        return messages
+    if any(isinstance(msg, dict) and msg.get("role") in {"system", "developer"} and _has_marker(msg.get("content")) for msg in messages):
+        return messages
+    block = _block()
+    cloned = [dict(msg) if isinstance(msg, dict) else msg for msg in messages]
+    if cloned and isinstance(cloned[0], dict) and cloned[0].get("role") in {"system", "developer"}:
+        first = dict(cloned[0])
+        content = first.get("content")
+        if isinstance(content, list):
+            first["content"] = [*content, {"type": "text", "text": block}]
+        else:
+            text = str(content or "").rstrip()
+            first["content"] = f"{text}\n\n{block}" if text else block
+        cloned[0] = first
+        return cloned
+    return [{"role": "system", "content": block}, *cloned]

--- a/agent/transports/__init__.py
+++ b/agent/transports/__init__.py
@@ -6,6 +6,8 @@ Usage:
     result = transport.normalize_response(raw_response)
 """
 
+from functools import wraps
+
 from agent.transports.types import (
     NormalizedResponse,
     ToolCall,
@@ -18,9 +20,38 @@ _REGISTRY: dict = {}
 _discovered: bool = False
 
 
+def _prepare_messages(messages):
+    try:
+        from agent.simplicio_prompt import apply_simplicio_prompt
+
+        return apply_simplicio_prompt(messages)
+    except Exception:
+        return messages
+
+
+def _wrap_transport_class(transport_cls: type) -> type:
+    build_kwargs = getattr(transport_cls, "build_kwargs", None)
+    if build_kwargs is None or getattr(build_kwargs, "_simplicio_prompt_prepared", False):
+        return transport_cls
+
+    @wraps(build_kwargs)
+    def _wrapped_build_kwargs(self, model, messages, tools=None, **params):
+        return build_kwargs(
+            self,
+            model,
+            _prepare_messages(messages),
+            tools=tools,
+            **params,
+        )
+
+    setattr(_wrapped_build_kwargs, "_simplicio_prompt_prepared", True)
+    setattr(transport_cls, "build_kwargs", _wrapped_build_kwargs)
+    return transport_cls
+
+
 def register_transport(api_mode: str, transport_cls: type) -> None:
     """Register a transport class for an api_mode string."""
-    _REGISTRY[api_mode] = transport_cls
+    _REGISTRY[api_mode] = _wrap_transport_class(transport_cls)
 
 
 def get_transport(api_mode: str):


### PR DESCRIPTION
## Summary

- Adds `agent/simplicio_prompt.py`, an optional before-LLM message preparation helper for `simplicio-prompt`.
- Wires the transport registry so registered provider transports prepare outbound messages before building provider kwargs.
- Keeps behavior opt-in via `HERMES_SIMPLICIO_PROMPT=1`, `SIMPLICIO_PROMPT=1`, or `YOOL_TUPLE_FULL_RUNTIME=1`.

## Notes

- This PR was opened with the current branch state as requested.
- I did not run the test suite in this environment.

## Validation

Not run.