### PR TITLE
perf+fix: take upstream WAL truncate, correct Rust dispatch, unbreak telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,32 @@ All notable changes to Hermes Turbo Agent are recorded here. Format follows
 
 ## [Unreleased]
 
+### Performance
+
+- Corrected the optional Rust hot-path dispatch in `agent/_hermes_fast.py`.
+  Benchmarks showed the `hermes_fast` bridge is a net *loss* for token
+  estimation/truncation (the JSON-serialize + FFI boundary swamps the trivial
+  `(len+3)//4` math) and only wins for `parse_tool_call_delta` (~3×). The
+  wrapper now reserves Rust for delta parsing and keeps estimation/truncation
+  on the faster pure-Python path even when the extension is built; set
+  `HERMES_RUST_ESTIMATES=1` to force the Rust path for estimates.
+- `SessionDB` now uses a `TRUNCATE` WAL checkpoint (was `PASSIVE`) in
+  `_try_wal_checkpoint()` and `close()`, so `state.db-wal` is shrunk instead of
+  only flushed — prevents unbounded WAL growth (ported from upstream Hermes
+  `46b2afc56`, #24034; aligns with the fork's disk-GC guardrail).
+
 ### Fixed
+
+- Restored the four token-economy telemetry modules (`token_savings`,
+  `gain_analytics`, `stage_timer`, `dashboard`) that a prior cleanup removed
+  while leaving their shipped #136–#139 consumers in place; `hermes report
+  savings` and the `/perf` stage-summary view were hard-broken by the missing
+  `agent.telemetry.token_savings` import and now work again.
+- `scripts/benchmark_startup_perf.py` now accepts `--case` (matching the
+  runtime runner), so `scripts/perf_budgets.py` no longer reports the three
+  startup cases as *"benchmark did not produce a result."*
+- `scripts/perf_budgets.py` marks cases from a skipped runner as `skipped`
+  instead of emitting false `error` warnings.
 
 - MCP OAuth no longer auto-opens browser authorization pages, or waits for
   loopback callbacks, from non-interactive contexts such as the gateway/cron

--- a/GOAL_RESULT.md
+++ b/GOAL_RESULT.md
@@ -1,5 +1,41 @@
 # Goal Result
 
+## Cycle 2026-06-05 — upstream review, operational, speed
+
+**Operator ask:** run the Hermes / Hermes Turbo update, see everything that
+changed, keep our changes, verify whether the upstream update is faster than
+what we built, and do whatever it takes to make the app operational and faster.
+
+**Outcome:**
+
+- **App is operational.** The environment had zero project deps installed (CLI
+  couldn't import). Installed core runtime + `[fast]` extra + built the Rust
+  wheel; `hermes --help`, `hermes report savings`, and
+  `hermes migrate-from-openclaw --benchmark` all run.
+- **Upstream is not faster than us.** All 50 newest upstream commits are
+  bug/stability fixes — none touch performance. The Turbo speed stack stands.
+  Full classification + evidence: `docs/upstream-sync/2026-06-05-review.md`.
+- **Took the single upstream win:** WAL `TRUNCATE` checkpoint (#24034) to stop
+  unbounded `state.db-wal` growth (disk-GC guardrail).
+- **Made it faster / unbroke it (fork work):**
+  - Rust dispatch corrected — Rust was a net loss for token estimation; now
+    reserved for `parse_tool_call_delta` (~3× win) only.
+  - `hermes report savings` + `/perf` un-broken by restoring four deleted
+    token-economy telemetry modules.
+  - Perf-budget tooling fixed (`--case` support; honest `--skip` reporting).
+
+**Validation:** 320 passed / 2 skipped final gate; perf budgets 4/5 under budget
+(the 5th is shared-CPU benchmark noise on a non-blocking alarm).
+
+Changed files: `hermes_state.py`, `agent/_hermes_fast.py`,
+`agent/telemetry/__init__.py` (+restored `token_savings.py`,
+`gain_analytics.py`, `stage_timer.py`, `dashboard.py`),
+`scripts/benchmark_startup_perf.py`, `scripts/perf_budgets.py`,
+`tests/agent/test_hermes_fast.py`, `scripts/upstream-sync/sync-state.json`,
+`docs/upstream-sync/2026-06-05-review.md`, `CHANGELOG.md`, `PROGRESS.md`.
+
+---
+
 ## Summary
 
 Closed all four open feature issues on `wesleysimplicio/hermes-turbo-agent`:

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,41 @@
 # Progress Log
 
+## Cycle 2026-06-05 — upstream review + operational + speed
+
+Goal (operator): run the Hermes/Turbo update, see what changed, keep our
+changes, verify whether upstream is faster than ours, and make the app
+operational and faster.
+
+What landed:
+
+1. **Operational baseline.** Container shipped with **no deps installed** — CLI
+   could not import (`No module named 'dotenv'`). Installed core runtime +
+   `[fast]` extra (orjson/uvloop) + built the Rust wheel. `hermes --help`,
+   `hermes report savings`, `hermes migrate-from-openclaw --benchmark` all run.
+2. **Upstream review** (`docs/upstream-sync/2026-06-05-review.md`). Captured the
+   50 newest upstream commits (HEAD `80672754`). **None are speed work** — all
+   bug/stability fixes. Verdict: upstream is *not* faster than the Turbo stack.
+   Recorded the baseline in `scripts/upstream-sync/sync-state.json`.
+3. **Took the one good upstream fix:** WAL `TRUNCATE` checkpoint in
+   `hermes_state.py` (upstream `46b2afc56`, #24034) — stops unbounded
+   `state.db-wal` growth; matches the disk-GC guardrail. 234 state tests pass.
+4. **Speed fix — Rust dispatch** (`agent/_hermes_fast.py`). Measured the Rust
+   bridge as a *net loss* for estimation/truncation (FFI + JSON-serialize cost)
+   and a ~3× win only for `parse_tool_call_delta`. Now routes accordingly;
+   `HERMES_RUST_ESTIMATES=1` opts back in. +3 tests (7 pass).
+5. **Perf-tooling bugs.** `benchmark_startup_perf.py` lacked `--case`, so
+   `perf_budgets.py` always failed its 3 startup cases — fixed. `perf_budgets.py`
+   now marks skipped runners as `skipped`, not false `error`s.
+6. **Operational regression fixed.** A prior "keep only benchmark winners"
+   cleanup deleted `token_savings`/`gain_analytics`/`stage_timer`/`dashboard`
+   but left their shipped #136–#139 consumers + tests, hard-breaking
+   `hermes report savings`. Restored all four (stdlib-only, `keep-turbo`).
+
+Validation: final gate **320 passed, 2 skipped** across `_hermes_fast`,
+telemetry, state/WAL, web_perf, migrate_openclaw, scripts. Perf budgets: 4/5
+under budget; `parallel_guard_read_files` over by 1.29× (shared-CPU noise,
+non-blocking).
+
 ## Current Status
 
 Open issues #136–#139 are implemented on branch

--- a/agent/_hermes_fast.py
+++ b/agent/_hermes_fast.py
@@ -2,22 +2,38 @@
 
 Phase 3 (perf): thin Python wrapper around the ``hermes_fast`` PyO3
 extension built by ``rust_ext/``. When the compiled extension is
-available we route ``estimate_tokens`` / ``truncate_messages_to_limit``
-/ ``parse_tool_call_delta`` through Rust. When it isn't (no Rust
-toolchain, Termux, source-only install) we fall back to pure-Python
-implementations that match existing agent semantics exactly so the
-fallback path is a drop-in replacement.
+unavailable (no Rust toolchain, Termux, source-only install) we fall
+back to pure-Python implementations that match existing agent semantics
+exactly, so the fallback path is a drop-in replacement.
+
+Dispatch policy (measured 2026-06, varied sizes, best-of-5):
+
+- ``parse_tool_call_delta`` is routed through Rust whenever the
+  extension is present — its input is already a string and the work is
+  real JSON parsing, so Rust wins **~3x** with no marshalling tax.
+- ``estimate_tokens`` / ``estimate_tokens_many`` /
+  ``estimate_messages_tokens`` / ``truncate_messages_to_limit`` default
+  to **pure Python**, even when the extension is present. Those ops are
+  dominated by the ``_fast_dumps_bytes`` JSON-serialize + FFI boundary
+  crossing they must do *before* Rust can touch the data; that overhead
+  swamps the trivial ``(len+3)//4`` arithmetic, so Python is reliably
+  1.1-1.5x faster (and the gap widens with batch size). Set
+  ``HERMES_RUST_ESTIMATES=1`` to force the Rust path for these if a
+  future extension build changes the trade-off (e.g. a zero-copy API
+  that no longer needs the pre-serialization pass).
 
 Build the extension with::
 
     cd rust_ext && maturin develop --release
 
-``HAVE_RUST`` reports which path is active.
+``HAVE_RUST`` reports whether the extension is loaded; it does not by
+itself mean estimation runs in Rust (see policy above).
 """
 
 from __future__ import annotations
 
 import json
+import os
 from typing import Any, Iterable
 
 from agent._fastjson import _fast_dumps, _fast_dumps_bytes, _fast_loads
@@ -29,6 +45,15 @@ try:
 except ImportError:  # pragma: no cover - fallback path
     _rust = None  # type: ignore
     HAVE_RUST = False
+
+# Opt-in override: route estimation/truncation through Rust despite the
+# measured boundary-cost penalty. Off by default — see the module docstring.
+_USE_RUST_ESTIMATES = os.getenv("HERMES_RUST_ESTIMATES") == "1"
+
+
+def _rust_estimates_active() -> bool:
+    """True only when the extension is loaded AND the opt-in flag is set."""
+    return _rust is not None and _USE_RUST_ESTIMATES
 
 
 def parse_tool_call_delta(buf: str) -> tuple[bool, Any, int]:
@@ -56,7 +81,7 @@ def parse_tool_call_delta(buf: str) -> tuple[bool, Any, int]:
 
 def estimate_tokens(text: str) -> int:
     """~4 chars/token heuristic. Empty => 0. Else ceil(len/4)."""
-    if _rust is not None:
+    if _rust_estimates_active():
         return _rust.estimate_tokens(text)  # type: ignore[attr-defined]
     if not text:
         return 0
@@ -72,7 +97,7 @@ def _estimate_tokens_local(text: str) -> int:
 def estimate_tokens_many(texts: Iterable[str]) -> list[int]:
     """Estimate many strings with one Rust boundary crossing when available."""
     text_list = [text if isinstance(text, str) else str(text) for text in texts]
-    if _rust is not None:
+    if _rust_estimates_active():
         return list(_rust.estimate_tokens_many(text_list))  # type: ignore[attr-defined]
     return [_estimate_tokens_local(text) for text in text_list]
 
@@ -106,7 +131,7 @@ def _py_message_cost(msg: dict[str, Any]) -> int:
 def estimate_messages_tokens(messages: Iterable[dict[str, Any]]) -> int:
     """Estimate the total token budget for OpenAI-style message dicts."""
     msg_list = list(messages)
-    if _rust is not None:
+    if _rust_estimates_active():
         encoded = _fast_dumps_bytes(msg_list, ensure_ascii=False)
         if hasattr(_rust, "estimate_messages_tokens_bytes"):
             return int(_rust.estimate_messages_tokens_bytes(encoded))  # type: ignore[attr-defined]
@@ -123,7 +148,7 @@ def truncate_messages_to_limit(
     dicts. Returns a new list. System messages are preserved.
     """
     msg_list = list(messages)
-    if _rust is not None:
+    if _rust_estimates_active():
         encoded = _fast_dumps_bytes(msg_list, ensure_ascii=False)
         if hasattr(_rust, "truncate_messages_to_limit_bytes"):
             out = _rust.truncate_messages_to_limit_bytes(encoded, int(max_tokens))  # type: ignore[attr-defined]

--- a/agent/telemetry/__init__.py
+++ b/agent/telemetry/__init__.py
@@ -1,8 +1,21 @@
 """Telemetry helpers for Hermes Turbo Agent.
 
-Trimmed to the modules that survived the post-mortem benchmark cleanup
-(turbo-vs-baseline). Only ``receipts`` (content-addressable append-only
-ledger from P7) and the deterministic content_hash primitive remain.
+Surfaces (all stdlib-only, no secrets):
+
+- ``receipts`` — content-addressable append-only ledger (P7) + the
+  deterministic ``content_hash`` primitive.
+- ``token_savings`` — JSONL ledger of compression savings events; the
+  data layer behind ``hermes report savings`` (#138).
+- ``gain_analytics`` — aggregation/trends over the token-savings ledger.
+- ``stage_timer`` / ``dashboard`` — per-stage timing ledger + percentile
+  summaries surfaced by the ``/perf`` web view (#137).
+- ``savings_report`` — weekly token-savings report with USD valuation.
+
+Note: an earlier "keep only benchmark winners" cleanup removed the four
+token-economy modules above while leaving their shipped #136-#139
+consumers (and tests) in place, which hard-broke ``hermes report
+savings``. They are intentionally retained here per the upstream-sync
+``token-economy-and-telemetry-optimizations`` keep-turbo rule.
 """
 
 from agent.telemetry.receipts import (

--- a/agent/telemetry/dashboard.py
+++ b/agent/telemetry/dashboard.py
@@ -1,0 +1,137 @@
+"""CLI dashboard: reads the telemetry JSONL and prints per-stage percentiles.
+
+Usage:
+    python -m agent.telemetry.dashboard [--log PATH] [--group-by stage|provider|model|tool]
+
+Outputs an ASCII table with count, p50, p95, p99, and mean (milliseconds) per
+group key. Pure stdlib; safe to run offline against a captured log.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+from .stage_timer import get_log_path
+
+
+GROUP_KEYS = ("stage", "provider", "model", "tool")
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float:
+    if not sorted_values:
+        return 0.0
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    # Nearest-rank percentile (no interpolation, stdlib only).
+    k = max(0, min(len(sorted_values) - 1, int(round(pct / 100.0 * (len(sorted_values) - 1)))))
+    return sorted_values[k]
+
+
+def _iter_events(path: Path) -> Iterable[dict]:
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def summarize(path: Path, group_by: str = "stage") -> list[dict]:
+    """Aggregate JSONL events into per-group percentile rows."""
+    if group_by not in GROUP_KEYS:
+        raise ValueError(f"group_by must be one of {GROUP_KEYS}, got {group_by!r}")
+    buckets: dict[str, list[float]] = defaultdict(list)
+    errors: dict[str, int] = defaultdict(int)
+    for event in _iter_events(path):
+        key = event.get(group_by) or "(none)"
+        try:
+            buckets[key].append(float(event.get("duration_ms", 0.0)))
+        except (TypeError, ValueError):
+            continue
+        if not event.get("ok", True):
+            errors[key] += 1
+    rows: list[dict] = []
+    for key, durations in buckets.items():
+        durations.sort()
+        count = len(durations)
+        rows.append(
+            {
+                "key": key,
+                "count": count,
+                "errors": errors.get(key, 0),
+                "p50_ms": round(_percentile(durations, 50), 2),
+                "p95_ms": round(_percentile(durations, 95), 2),
+                "p99_ms": round(_percentile(durations, 99), 2),
+                "mean_ms": round(sum(durations) / count, 2) if count else 0.0,
+            }
+        )
+    rows.sort(key=lambda r: r["p95_ms"], reverse=True)
+    return rows
+
+
+def format_table(rows: list[dict], group_by: str) -> str:
+    header = (group_by, "count", "errors", "p50_ms", "p95_ms", "p99_ms", "mean_ms")
+    widths = [max(len(h), 8) for h in header]
+    str_rows = []
+    for r in rows:
+        cells = (
+            str(r["key"]),
+            str(r["count"]),
+            str(r["errors"]),
+            f"{r['p50_ms']:.2f}",
+            f"{r['p95_ms']:.2f}",
+            f"{r['p99_ms']:.2f}",
+            f"{r['mean_ms']:.2f}",
+        )
+        str_rows.append(cells)
+        for i, c in enumerate(cells):
+            widths[i] = max(widths[i], len(c))
+    sep_line = "+".join("-" * (w + 2) for w in widths)
+    sep_line = f"+{sep_line}+"
+
+    def fmt(cells: tuple[str, ...]) -> str:
+        return "| " + " | ".join(c.ljust(w) for c, w in zip(cells, widths)) + " |"
+
+    lines = [sep_line, fmt(header), sep_line]
+    lines.extend(fmt(c) for c in str_rows)
+    lines.append(sep_line)
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Hermes runtime telemetry dashboard")
+    parser.add_argument("--log", type=Path, default=None, help="path to telemetry JSONL")
+    parser.add_argument(
+        "--group-by",
+        choices=GROUP_KEYS,
+        default="stage",
+        help="group events by this field (default: stage)",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of table")
+    args = parser.parse_args(argv)
+
+    path = args.log or get_log_path()
+    rows = summarize(path, group_by=args.group_by)
+    if not rows:
+        print(f"no telemetry events found at {path}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(rows, indent=2))
+    else:
+        print(f"telemetry: {path}  ({sum(r['count'] for r in rows)} events)")
+        print(format_table(rows, args.group_by))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agent/telemetry/gain_analytics.py
+++ b/agent/telemetry/gain_analytics.py
@@ -1,0 +1,108 @@
+"""Gain analytics CLI for token savings telemetry. See docs/perf/."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable, Optional
+
+from agent.telemetry.token_savings import default_log_path, iter_records
+
+
+def _int(rec: dict, key: str) -> int:
+    try:
+        return int(rec.get(key, 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _day(ts: str) -> str:
+    return ts[:10] if isinstance(ts, str) and len(ts) >= 10 else "unknown"
+
+
+def aggregate(records: Iterable[dict]) -> dict:
+    total_raw = total_comp = count = 0
+    by_tool: dict[str, dict[str, int]] = defaultdict(lambda: {"raw": 0, "saved": 0, "calls": 0})
+    by_day: dict[str, dict[str, int]] = defaultdict(lambda: {"raw": 0, "saved": 0, "calls": 0})
+    by_adapter: dict[str, int] = defaultdict(int)
+
+    for rec in records:
+        raw, comp = _int(rec, "raw_tokens"), _int(rec, "compressed_tokens")
+        saved = _int(rec, "saved_tokens") or max(0, raw - comp)
+        total_raw += raw
+        total_comp += comp
+        count += 1
+        for bucket, key in ((by_tool, str(rec.get("tool") or "unknown")),
+                            (by_day, _day(str(rec.get("ts") or "")))):
+            bucket[key]["raw"] += raw
+            bucket[key]["saved"] += saved
+            bucket[key]["calls"] += 1
+        by_adapter[str(rec.get("adapter") or "unknown")] += saved
+
+    saved_total = max(0, total_raw - total_comp)
+    pct = round(100.0 * saved_total / total_raw, 2) if total_raw else 0.0
+    return {
+        "records": count,
+        "total_raw_tokens": total_raw,
+        "total_compressed_tokens": total_comp,
+        "total_saved_tokens": saved_total,
+        "overall_savings_pct": pct,
+        "by_tool": dict(by_tool),
+        "by_day": dict(by_day),
+        "by_adapter": dict(by_adapter),
+    }
+
+
+def top_wasteful_tools(agg: dict, limit: int = 5) -> list[tuple[str, int, int]]:
+    """Return (tool, raw_tokens, saved_tokens) sorted by raw desc."""
+    items = [(t, v["raw"], v["saved"]) for t, v in agg.get("by_tool", {}).items()]
+    items.sort(key=lambda r: r[1], reverse=True)
+    return items[: max(0, limit)]
+
+
+def trend(agg: dict) -> list[tuple[str, int, int]]:
+    """Return (day, raw, saved) sorted by day ascending."""
+    items = [(d, v["raw"], v["saved"]) for d, v in agg.get("by_day", {}).items()]
+    items.sort(key=lambda r: r[0])
+    return items
+
+
+def _format_report(agg: dict, top_n: int) -> str:
+    head = [
+        "Hermes Turbo - Token Savings Report", "-" * 40,
+        f"Records:           {agg['records']}",
+        f"Raw tokens:        {agg['total_raw_tokens']}",
+        f"Compressed tokens: {agg['total_compressed_tokens']}",
+        f"Saved tokens:      {agg['total_saved_tokens']}",
+        f"Overall savings:   {agg['overall_savings_pct']}%", "",
+        f"Top {top_n} tools by raw tokens spent:",
+    ]
+    head += [f"  - {t:<24} raw={r:>8} saved={s:>8}" for t, r, s in top_wasteful_tools(agg, top_n)]
+    head += ["", "Daily trend:"]
+    head += [f"  {d}  raw={r:>8}  saved={s:>8}" for d, r, s in trend(agg)]
+    return "\n".join(head)
+
+
+def run(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="hermes-token-savings",
+        description="Aggregate Hermes Turbo token-savings telemetry.",
+    )
+    parser.add_argument("--log", type=Path, default=None, help="JSONL log path.")
+    parser.add_argument("--top", type=int, default=5, help="How many tools to list.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON.")
+    args = parser.parse_args(argv)
+    agg = aggregate(iter_records(args.log or default_log_path()))
+    if args.json:
+        json.dump(agg, sys.stdout, ensure_ascii=False, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(_format_report(agg, args.top) + "\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(run())

--- a/agent/telemetry/stage_timer.py
+++ b/agent/telemetry/stage_timer.py
@@ -1,0 +1,117 @@
+"""Stage timing primitive: context manager that appends a JSONL event per stage.
+
+Privacy: only stage name, duration, and coarse labels (provider/model/tool) are
+captured. Never logs prompt content, secrets, or arbitrary user data. Callers
+must pass already-redacted labels.
+
+Usage:
+    from agent.telemetry import StageTimer
+
+    with StageTimer("context_build", provider="deepseek", model="deepseek-chat"):
+        build_context(...)
+
+The log path defaults to ``$HERMES_TELEMETRY_LOG`` or ``~/.hermes/telemetry.jsonl``.
+File writes are best-effort; failures never raise into the hot path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+
+_DEFAULT_LOG = Path.home() / ".hermes" / "telemetry.jsonl"
+_log_path: Optional[Path] = None
+
+
+def set_log_path(path: str | os.PathLike[str]) -> None:
+    """Override the JSONL output path (mainly for tests)."""
+    global _log_path
+    _log_path = Path(path)
+
+
+def get_log_path() -> Path:
+    """Resolve the active JSONL output path."""
+    if _log_path is not None:
+        return _log_path
+    env = os.environ.get("HERMES_TELEMETRY_LOG")
+    return Path(env) if env else _DEFAULT_LOG
+
+
+def record_stage(
+    stage: str,
+    duration_ms: float,
+    *,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    tool: Optional[str] = None,
+    ok: bool = True,
+    meta: Optional[dict[str, Any]] = None,
+) -> None:
+    """Append a single stage event to the JSONL log. Best-effort, never raises."""
+    event = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        "stage": stage,
+        "duration_ms": round(float(duration_ms), 3),
+        "provider": provider,
+        "model": model,
+        "tool": tool,
+        "ok": bool(ok),
+        "meta": meta or {},
+    }
+    try:
+        path = get_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event, ensure_ascii=False) + "\n")
+    except Exception:  # noqa: BLE001 - telemetry must never break runtime
+        return
+
+
+class StageTimer:
+    """Context manager that times a runtime stage and emits a JSONL event.
+
+    Sets ``ok=False`` automatically if the block raises. The exception still
+    propagates; telemetry is side-effect only.
+    """
+
+    __slots__ = ("stage", "provider", "model", "tool", "meta", "_t0", "ok", "duration_ms")
+
+    def __init__(
+        self,
+        stage: str,
+        *,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        tool: Optional[str] = None,
+        meta: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self.stage = stage
+        self.provider = provider
+        self.model = model
+        self.tool = tool
+        self.meta = meta
+        self._t0 = 0.0
+        self.ok = True
+        self.duration_ms = 0.0
+
+    def __enter__(self) -> "StageTimer":
+        self._t0 = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.duration_ms = (time.perf_counter() - self._t0) * 1000.0
+        self.ok = exc_type is None
+        record_stage(
+            self.stage,
+            self.duration_ms,
+            provider=self.provider,
+            model=self.model,
+            tool=self.tool,
+            ok=self.ok,
+            meta=self.meta,
+        )

--- a/agent/telemetry/token_savings.py
+++ b/agent/telemetry/token_savings.py
@@ -1,0 +1,98 @@
+"""Token savings telemetry (JSONL, no secrets). See docs/perf/."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, Optional
+
+_ENV = "HERMES_TOKEN_SAVINGS_LOG"
+_REL = Path(".hermes") / "telemetry" / "token_savings.jsonl"
+
+
+def default_log_path() -> Path:
+    """Return the JSONL log path (env override or ``~/.hermes/...``)."""
+    override = os.environ.get(_ENV)
+    return Path(override).expanduser() if override else Path.home() / _REL
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass(frozen=True)
+class TokenSavingRecord:
+    """A single token-savings event."""
+
+    raw_tokens: int
+    compressed_tokens: int
+    tool: str = "unknown"
+    command: str = "unknown"
+    adapter: str = "unknown"
+    session: str = "unknown"
+    repo: str = "unknown"
+    ts: str = field(default_factory=_utc_now)
+    savings_pct: float = 0.0
+
+    @property
+    def saved_tokens(self) -> int:
+        return max(0, self.raw_tokens - self.compressed_tokens)
+
+    def to_json(self) -> str:
+        payload = asdict(self)
+        payload["saved_tokens"] = self.saved_tokens
+        return json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+
+
+def _pct(raw: int, comp: int) -> float:
+    if raw <= 0:
+        return 0.0
+    return round(100.0 * max(0, raw - comp) / raw, 2)
+
+
+def record_token_saving(
+    raw_tokens: int,
+    compressed_tokens: int,
+    *,
+    tool: str = "unknown",
+    command: str = "unknown",
+    adapter: str = "unknown",
+    session: str = "unknown",
+    repo: str = "unknown",
+    log_path: Optional[Path] = None,
+) -> TokenSavingRecord:
+    """Append a savings entry. Silent on disk errors."""
+    raw = max(0, int(raw_tokens))
+    comp = min(max(0, int(compressed_tokens)), raw)
+    record = TokenSavingRecord(
+        raw_tokens=raw, compressed_tokens=comp,
+        tool=tool, command=command, adapter=adapter, session=session, repo=repo,
+        savings_pct=_pct(raw, comp),
+    )
+    path = Path(log_path) if log_path else default_log_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(record.to_json() + "\n")
+    except OSError:
+        pass  # Telemetry must never break the caller.
+    return record
+
+
+def iter_records(log_path: Optional[Path] = None) -> Iterator[dict]:
+    """Yield each JSON object from the savings log. Skips malformed lines."""
+    path = Path(log_path) if log_path else default_log_path()
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue

--- a/docs/upstream-sync/2026-06-05-review.md
+++ b/docs/upstream-sync/2026-06-05-review.md
@@ -1,0 +1,114 @@
+# Upstream Hermes review — 2026-06-05
+
+This is a **review-and-cherry-pick** sync, not a full merge. We captured the
+latest upstream Hermes commits, classified each, decided what (if anything)
+beats the Turbo fork, and pulled only the changes worth taking. The focus of
+this cycle was **speed and getting the app operational**.
+
+## Inputs
+
+- Upstream: `https://github.com/NousResearch/hermes-agent.git` (branch `main`)
+- Upstream HEAD reviewed: `80672754a875fe7ac0f231054918d47272097f9e`
+- Previous recorded sync SHA: *(empty — first recorded baseline)*
+- Captured via `scripts/upstream-sync/capture-upstream.sh` (last 50 commits)
+
+## Verdict on speed: upstream is **not** faster than the Turbo fork
+
+We classified all 50 newest upstream commits. **None are performance/speed
+work** — they are bug and stability fixes:
+
+| Theme | Examples (upstream) |
+|---|---|
+| desktop/TUI | thinking-block streaming, slash-command queue, accordion settings |
+| docker | orphaned-container cleanup, out-of-band removal recovery |
+| ssh/uv | WinError 1314 symlink fallback, venv rebuild on Windows |
+| web/SSRF | run URL checks off the event loop |
+| gateway/mcp | zombie-slot clearing, server.shutdown on probe failure |
+| messaging | slack `thread_ts`, telegram sealed-overflow chunk |
+| state | **WAL TRUNCATE checkpoint** (the one we took — see below) |
+
+Conclusion: the Turbo speed stack (`agent/_fastjson.py`, `agent/_hermes_fast.py`,
+`agent/uvloop_utils.py`, the token-economy telemetry, `scripts/perf_budgets.py`,
+the Turbo Score) is **not superseded** by anything upstream shipped. Our
+`token-economy-and-telemetry-optimizations` and `performance-patches-and-budgets`
+sync rules stand.
+
+## Changes taken from upstream
+
+### `fix(state)` WAL `TRUNCATE` checkpoint (upstream `46b2afc56`, #24034)
+
+The only upstream change that is strictly better than ours. We were still on
+`PRAGMA wal_checkpoint(PASSIVE)` in `SessionDB._try_wal_checkpoint()` and
+`close()`, which flushes WAL frames but **never shrinks** `state.db-wal` — it
+grows to its high-water mark and stays there. Switched both call sites to
+`TRUNCATE`. This is directly aligned with the fork's mandatory disk-GC
+guardrail (CLAUDE.md §11.2 — *"garbage collector também pra não encher 100% do
+disco"*). 234 state/WAL tests pass.
+
+## Independent fork improvements made this cycle (speed + operational)
+
+These are **ours**, found while making the app run; they are not upstream
+ports.
+
+1. **`agent/_hermes_fast.py` — Rust dispatch corrected (real speed win).**
+   Benchmarking the optional Rust hot-path (`hermes_fast`, built via
+   `rust_ext/`) against the pure-Python fallback showed the bridge is a **net
+   loss** for token estimation/truncation, because those ops must
+   JSON-serialize the whole message list and cross the FFI boundary before
+   Rust can touch the data — and that overhead dwarfs the trivial `(len+3)//4`
+   arithmetic:
+
+   | hot path | Rust vs Python | winner |
+   |---|---|---|
+   | `parse_tool_call_delta` | **2.9–3.7×** | **Rust** (real parse, no pre-serialize) |
+   | `estimate_messages_tokens` | 0.66–0.90× | Python |
+   | `truncate_messages_to_limit` | 0.64–0.84× | Python |
+   | `estimate_tokens_many` | wash (1.1× small → 0.69× large) | Python |
+
+   Fix: route only `parse_tool_call_delta` through Rust; estimation/truncation
+   default to the faster pure-Python path even when the extension is loaded.
+   `HERMES_RUST_ESTIMATES=1` opts back in. The module docstring told users to
+   build Rust "for perf"; following that advice previously made estimation
+   *slower*. Now corrected and documented.
+
+2. **`scripts/benchmark_startup_perf.py` — added `--case` filtering.**
+   `scripts/perf_budgets.py` passes `--case <name>` to both runners, but the
+   startup runner didn't accept it, so it exited with code 2 and the three
+   startup budgets (`import_model_tools`, `get_tool_definitions`,
+   `session_append_messages_batch`) **always** reported *"benchmark did not
+   produce a result."* Now they report (all far under budget: 0.11×/0.15×/0.02×).
+
+3. **`scripts/perf_budgets.py` — honest `--skip-*` reporting.** Skipped runners'
+   cases are now marked `skipped` instead of falsely reported as `error` +
+   warning.
+
+4. **Restored four token-economy telemetry modules** (`token_savings`,
+   `gain_analytics`, `stage_timer`, `dashboard`). A prior *"keep only benchmark
+   winners"* cleanup deleted them but left their shipped #136–#139 consumers
+   and tests in place, hard-breaking `hermes report savings` (unguarded
+   top-level import). All four are stdlib-only, self-contained, and
+   `keep-turbo` per the sync policy. `hermes report savings` and the `/perf`
+   stage-summary view work again.
+
+## Operational baseline established
+
+The container shipped with **no project dependencies installed** — the CLI
+could not import (`No module named 'dotenv'`). Installed the core runtime +
+the `[fast]` extra (orjson/uvloop) + built the Rust wheel. `hermes --help`,
+`hermes report savings`, and `hermes migrate-from-openclaw --benchmark` all run.
+
+## Perf-budget snapshot (post-change, 3 samples, shared CI CPU)
+
+| case | median | budget | ratio | status |
+|---|---:|---:|---:|---|
+| import_model_tools | 0.278s | 2.5s | 0.11× | ok |
+| get_tool_definitions | 0.222s | 1.5s | 0.15× | ok |
+| session_append_messages_batch | 0.012s | 0.5s | 0.02× | ok |
+| parallel_guard_read_files | 0.645s | 0.5s | 1.29× | over (shared-CPU noise; non-blocking) |
+| openrouter_metadata_disk_cache | 0.279s | 1.5s | 0.19× | ok |
+
+`parallel_guard_read_files` is already orjson-accelerated (`_fast_loads`) with
+C-level path ops; the over-budget reading is shared-container CPU variance
+against a budget calibrated for ubuntu-latest 2-vCPU, and the budget is a
+non-blocking alarm by design. No change made to the correctness-critical
+parallel-safety guard.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -455,17 +455,26 @@ class SessionDB:
         )
 
     def _try_wal_checkpoint(self) -> None:
-        """Best-effort PASSIVE WAL checkpoint.  Never blocks, never raises.
+        """Best-effort TRUNCATE WAL checkpoint.  Never raises.
 
-        Flushes committed WAL frames back into the main DB file for any
-        frames that no other connection currently needs.  Keeps the WAL
+        Flushes committed WAL frames back into the main DB file *and*
+        truncates the WAL file to zero bytes.  Keeps ``state.db-wal``
         from growing unbounded when many processes hold persistent
         connections.
+
+        PASSIVE checkpoint was previously used here, but it never
+        truncates the WAL file — the file stays at its high-water mark
+        until an explicit TRUNCATE is issued (which only happened inside
+        the infrequent vacuum()), so the WAL grew without bound
+        (upstream #24034). TRUNCATE may block writers briefly while
+        checkpointing, but this runs off the hot path (every 50 writes)
+        and already holds ``self._lock``, so the extra hold time is
+        negligible — and it is what keeps the disk-GC guardrail honest.
         """
         try:
             with self._lock:
                 result = self._conn.execute(
-                    "PRAGMA wal_checkpoint(PASSIVE)"
+                    "PRAGMA wal_checkpoint(TRUNCATE)"
                 ).fetchone()
                 if result and result[1] > 0:
                     logger.debug(
@@ -478,13 +487,14 @@ class SessionDB:
     def close(self):
         """Close the database connection.
 
-        Attempts a PASSIVE WAL checkpoint first so that exiting processes
-        help keep the WAL file from growing unbounded.
+        Attempts a TRUNCATE WAL checkpoint first so that exiting
+        processes help *shrink* the WAL file rather than merely flushing
+        it (upstream #24034).
         """
         with self._lock:
             if self._conn:
                 try:
-                    self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+                    self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
                 except Exception:
                     pass
                 self._conn.close()

--- a/scripts/benchmark_startup_perf.py
+++ b/scripts/benchmark_startup_perf.py
@@ -144,11 +144,33 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("-n", "--samples", type=int, default=5)
     parser.add_argument("--json", action="store_true", help="Emit JSON instead of Markdown.")
+    parser.add_argument(
+        "--case",
+        action="append",
+        dest="cases",
+        metavar="NAME",
+        help=(
+            "Run only the named case (repeatable). Defaults to all cases. "
+            "Mirrors benchmark_runtime_usage.py so scripts/perf_budgets.py can "
+            "target a subset; unknown names are reported on stderr and skipped."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.cases:
+        selected = {}
+        for name in args.cases:
+            if name in CASES:
+                selected[name] = CASES[name]
+            else:
+                print(f"warning: unknown case '{name}' (skipped)", file=sys.stderr)
+        cases = selected
+    else:
+        cases = CASES
 
     results = {
         name: _summarize([_run_case(name, code) for _ in range(args.samples)])
-        for name, code in CASES.items()
+        for name, code in cases.items()
     }
 
     if args.json:

--- a/scripts/perf_budgets.py
+++ b/scripts/perf_budgets.py
@@ -174,6 +174,12 @@ def main() -> int:
     startup_cases = [c for c in _STARTUP_CASES if c in case_budgets]
     runtime_cases = [c for c in _RUNTIME_CASES if c in case_budgets]
 
+    skipped: set[str] = set()
+    if args.skip_startup:
+        skipped.update(startup_cases)
+    if args.skip_runtime:
+        skipped.update(runtime_cases)
+
     runner_output: dict = {}
     if startup_cases and not args.skip_startup:
         out = _run_benchmark("benchmark_startup_perf.py", startup_cases, args.samples)
@@ -182,7 +188,20 @@ def main() -> int:
         out = _run_benchmark("benchmark_runtime_usage.py", runtime_cases, args.samples)
         runner_output.update(out if isinstance(out, dict) else {})
 
-    rows = [_evaluate(case, budget, runner_output) for case, budget in case_budgets.items()]
+    rows = []
+    for case, budget in case_budgets.items():
+        if case in skipped:
+            # A runner was explicitly skipped — don't evaluate or warn on its
+            # cases, just record them as skipped so the report stays honest.
+            rows.append({
+                "case": case,
+                "status": "skipped",
+                "budget_seconds": budget,
+                "median_seconds": None,
+                "reason": "runner skipped",
+            })
+        else:
+            rows.append(_evaluate(case, budget, runner_output))
     warnings: list[str] = []
     for row in rows:
         if row["status"] == "over_budget":

--- a/scripts/upstream-sync/sync-state.json
+++ b/scripts/upstream-sync/sync-state.json
@@ -2,9 +2,9 @@
   "version": 1,
   "upstream_url": "https://github.com/NousResearch/hermes-agent.git",
   "upstream_branch": "main",
-  "last_sync_sha": "",
-  "last_sync_branch": "",
-  "last_sync_at": "",
-  "last_run_id": "",
-  "notes": "Updated after each successful sync by scripts/upstream-sync/capture-upstream.sh and reapply.sh. Leave last_sync_sha empty on first run to fall back to the last 50 upstream commits."
+  "last_sync_sha": "80672754a875fe7ac0f231054918d47272097f9e",
+  "last_sync_branch": "main",
+  "last_sync_at": "2026-06-05T00:00:00Z",
+  "last_run_id": "20260605-013107",
+  "notes": "2026-06-05 review-and-cherry-pick (not a full merge): all 50 newest upstream commits classified as bug/stability fixes, none speed-related. Took only the WAL TRUNCATE checkpoint fix (upstream 46b2afc56, #24034). See docs/upstream-sync/2026-06-05-review.md. Baseline recorded so the drift checker only alerts on commits past 80672754."
 }

--- a/tests/agent/test_hermes_fast.py
+++ b/tests/agent/test_hermes_fast.py
@@ -1,3 +1,4 @@
+import agent._hermes_fast as hermes_fast
 from agent._hermes_fast import (
     estimate_messages_tokens,
     estimate_tokens,
@@ -5,6 +6,32 @@ from agent._hermes_fast import (
     parse_tool_call_delta,
     truncate_messages_to_limit,
 )
+
+
+class _SentinelRust:
+    """Stand-in for the loaded Rust extension that flags which path ran.
+
+    Every routed call returns an obviously-wrong value so a test can assert
+    whether the Rust branch was taken (sentinel returned) or the Python
+    fallback was used (correct value returned).
+    """
+
+    SENTINEL_INT = -424242
+
+    def estimate_tokens(self, text):  # noqa: ARG002
+        return self.SENTINEL_INT
+
+    def estimate_tokens_many(self, texts):
+        return [self.SENTINEL_INT] * len(texts)
+
+    def estimate_messages_tokens(self, encoded):  # noqa: ARG002
+        return self.SENTINEL_INT
+
+    def truncate_messages_to_limit(self, encoded, max_tokens):  # noqa: ARG002
+        return b"[]"
+
+    def parse_tool_call_delta(self, buf):  # noqa: ARG002
+        return (True, {"sentinel": True}, len(buf))
 
 
 def test_estimate_tokens_many_matches_scalar_estimator():
@@ -53,3 +80,50 @@ def test_parse_tool_call_delta_handles_nested_tool_payloads():
     assert value["items"] == [1, 2.5, None]
     assert value["ok"] is True
     assert payload[consumed:] == " trailing"
+
+
+def test_estimates_stay_on_python_even_when_extension_present(monkeypatch):
+    """Default policy: estimation/truncation must NOT route through Rust.
+
+    Measured boundary cost makes Rust a net loss for these ops, so with the
+    extension loaded but the opt-in flag off, the pure-Python path runs.
+    """
+    monkeypatch.setattr(hermes_fast, "_rust", _SentinelRust())
+    monkeypatch.setattr(hermes_fast, "_USE_RUST_ESTIMATES", False)
+
+    messages = [
+        {"role": "system", "content": "abcd"},
+        {"role": "user", "content": "abcdefgh"},
+    ]
+    # If Rust had been used, every result would be the sentinel value.
+    assert estimate_tokens("abcd") == 1
+    assert estimate_tokens_many(["abcd", "abcdefgh"]) == [1, 2]
+    assert estimate_messages_tokens(messages) > 0
+    assert estimate_messages_tokens(messages) != _SentinelRust.SENTINEL_INT
+    keep = {"role": "system", "content": "k"}
+    drop = {"role": "user", "content": "x" * 80}
+    tail = {"role": "assistant", "content": "k"}
+    limit = estimate_messages_tokens([keep, tail])
+    assert truncate_messages_to_limit([keep, drop, tail], limit) == [keep, tail]
+
+
+def test_parse_tool_call_delta_routes_through_extension_when_present(monkeypatch):
+    """parse_tool_call_delta is the one op that always prefers Rust (~3x win)."""
+    monkeypatch.setattr(hermes_fast, "_rust", _SentinelRust())
+    # The opt-in flag is irrelevant for delta parsing.
+    monkeypatch.setattr(hermes_fast, "_USE_RUST_ESTIMATES", False)
+
+    ok, value, consumed = parse_tool_call_delta('{"a":1}')
+    assert ok is True
+    assert value == {"sentinel": True}
+
+
+def test_rust_estimates_flag_opts_back_into_rust(monkeypatch):
+    """HERMES_RUST_ESTIMATES=1 restores the Rust path for estimates."""
+    monkeypatch.setattr(hermes_fast, "_rust", _SentinelRust())
+    monkeypatch.setattr(hermes_fast, "_USE_RUST_ESTIMATES", True)
+
+    assert estimate_tokens("abcd") == _SentinelRust.SENTINEL_INT
+    assert estimate_messages_tokens([{"role": "user", "content": "x"}]) == (
+        _SentinelRust.SENTINEL_INT
+    )


### PR DESCRIPTION
## Context

`/loop` task: run the Hermes / Hermes Turbo update, see what changed, **keep our
changes**, verify whether the upstream update is faster than what we built, and
do whatever it takes to make the app **operational and faster**.

## Upstream review (review-and-cherry-pick, not a full merge)

Captured the **50 newest** `NousResearch/hermes-agent` commits (HEAD
`80672754`). **None are performance/speed work** — they are bug/stability
fixes (desktop, ssh, docker, tui, gateway, mcp, vision, telegram, slack).
**Verdict: upstream is not faster than the Turbo stack**, which therefore is
not superseded. Full classification + evidence in
`docs/upstream-sync/2026-06-05-review.md`; baseline recorded in
`scripts/upstream-sync/sync-state.json`.

## Performance

- **`hermes_state`: WAL `PASSIVE` → `TRUNCATE` checkpoint** in
  `_try_wal_checkpoint()` and `close()` — the *one* upstream change worth
  taking (`46b2afc56`, #24034). `PASSIVE` flushes but never shrinks
  `state.db-wal`, so it grows unbounded. Aligns with the fork's disk-GC
  guardrail.
- **`agent/_hermes_fast`: corrected the Rust hot-path dispatch.** Measured the
  optional `hermes_fast` bridge against pure Python:

  | hot path | Rust vs Python | winner |
  |---|---|---|
  | `parse_tool_call_delta` | **2.9–3.7×** | **Rust** |
  | `estimate_messages_tokens` | 0.66–0.90× | Python |
  | `truncate_messages_to_limit` | 0.64–0.84× | Python |
  | `estimate_tokens_many` | wash → 0.69× | Python |

  The bridge is a net **loss** for estimation/truncation (JSON-serialize + FFI
  boundary dwarfs `(len+3)//4`). Now Rust is reserved for delta parsing;
  estimation/truncation stay on the faster Python path even when the extension
  is built. `HERMES_RUST_ESTIMATES=1` opts back in. The module docstring used
  to tell users to build Rust "for perf" — which made estimation *slower*; now
  corrected and documented.

## Fixes (operational)

- **Un-broke `hermes report savings` + the `/perf` stage view.** A prior
  *"keep only benchmark winners"* cleanup deleted four token-economy telemetry
  modules (`token_savings`, `gain_analytics`, `stage_timer`, `dashboard`) but
  left their shipped #136–#139 consumers and tests in place — an unguarded
  top-level import of `agent.telemetry.token_savings` hard-broke the report
  command. Restored all four (stdlib-only, self-contained, `keep-turbo` per the
  sync policy).
- **`benchmark_startup_perf.py`: added `--case`** (matching the runtime
  runner), so `perf_budgets.py` stops reporting the three startup cases as
  *"benchmark did not produce a result."*
- **`perf_budgets.py`: honest `--skip` reporting** — skipped runners' cases are
  marked `skipped`, not false `error`s.

## Validation

- **320 passed / 2 skipped** across `_hermes_fast`, telemetry, state/WAL,
  `web_perf`, `migrate_openclaw`, scripts.
- CLI operational: `hermes --help`, `hermes report savings --json`,
  `hermes migrate-from-openclaw --benchmark` all run (the env shipped with no
  deps installed — core + `[fast]` extra + Rust wheel now in place).
- Perf budgets: 4/5 under budget; `parallel_guard_read_files` 1.29× over —
  shared-CPU benchmark noise on a non-blocking alarm; the guard is already
  orjson-accelerated, so no code change there.

## Notes / draft

Opened as **draft**. The restored telemetry modules reverse part of an earlier
intentional cleanup, but they back currently-shipped features (#136–#139) and
match the `token-economy-and-telemetry-optimizations` keep-turbo rule — flagging
for a maintainer sanity check before un-drafting.

https://claude.ai/code/session_01Prcfr5HRPH5yPK2m2gL9fH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Prcfr5HRPH5yPK2m2gL9fH)_