### PR TITLE
Add EvoLink model provider

### DIFF
--- a/plugins/model-providers/evolink/__init__.py
+++ b/plugins/model-providers/evolink/__init__.py
@@ -1,0 +1,25 @@
+"""EvoLink provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+evolink = ProviderProfile(
+    name="evolink",
+    aliases=("evolink-ai", "evolinkai"),
+    display_name="EvoLink",
+    description="EvoLink - unified AI model gateway",
+    signup_url="https://evolink.ai/dashboard/keys",
+    env_vars=("EVOLINK_API_KEY", "EVOLINK_BASE_URL"),
+    base_url="https://direct.evolink.ai/v1",
+    auth_type="api_key",
+    default_aux_model="gpt-5.2",
+    fallback_models=(
+        "gpt-5.2",
+        "gpt-5.1",
+        "gemini-3.1-flash-lite-preview",
+        "deepseek-v4-flash",
+    ),
+)
+
+register_provider(evolink)

--- a/plugins/model-providers/evolink/plugin.yaml
+++ b/plugins/model-providers/evolink/plugin.yaml
@@ -1,0 +1,5 @@
+name: evolink-provider
+kind: model-provider
+version: 1.0.0
+description: EvoLink unified AI model gateway
+author: Nous Research

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -46,19 +46,19 @@ def test_bundled_plugins_discovered():
         assert (child / "plugin.yaml").exists(), f"{child.name} missing plugin.yaml"
 
 
-def test_all_34_profiles_register():
-    """After discovery, the registry must contain exactly 34 distinct profiles."""
+def test_all_35_profiles_register():
+    """After discovery, the registry must contain exactly 35 distinct profiles."""
     _clear_provider_caches()
     from providers import list_providers
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    assert len(names) == 34, f"Expected 34 profiles, got {len(names)}: {names}"
+    assert len(names) == 35, f"Expected 35 profiles, got {len(names)}: {names}"
 
     # Spot-check representative providers from different categories
     for required in (
         "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
-        "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
+        "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan", "evolink",
     ):
         assert required in names, f"Missing profile: {required}"
 


### PR DESCRIPTION
## Summary
- Add EvoLink as a bundled OpenAI-compatible model-provider plugin
- Configure EVOLINK_API_KEY / EVOLINK_BASE_URL with the https://direct.evolink.ai/v1 endpoint
- Use gpt-5.2 as the concrete default auxiliary model and include a small fallback model list for picker use when live model discovery is unavailable

## Validation
- /opt/homebrew/bin/python3.12 provider profile assertion: resolved EvoLink profile, aliases, direct base URL, default model, and registry membership
- env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy uv run --no-project --with pytest --with pytest-timeout --with pytest-xdist --with pytest-split --with pyyaml pytest -o addopts= tests/providers/test_plugin_discovery.py -q
- git diff --check

## Notes
- This follows the existing plugins/model-providers ProviderProfile pattern; no core provider wiring changes are needed.
- I used a no-project pytest invocation because uv run --locked reports the existing uv.lock needs updating before this change.