### PR TITLE
docs: update turbo skill and localized READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,161 +20,103 @@
   <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
 </p>
 
-Executable installation and performance-optimization skill for Hermes Agent.
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-When installed and invoked for optimization, the skill identifies the authorized Hermes installation, installs optional accelerators, applies compatible changes, runs tests, and compares before/after benchmarks. It is not an executable Hermes fork.
+## 1. Scope and safety
 
-## What this skill recommends
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-### `orjson`
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-Evaluate `orjson` on hot JSON serialization and deserialization paths, such as messages, schemas, and tool calls.
+## 2. Performance modules
 
-Expected benefits:
+### Fast JSON and typed contracts
 
-- lower `json.loads` and `json.dumps` latency;
-- lower CPU cost for medium and large payloads;
-- higher message-processing throughput;
-- potentially fewer allocations on frequent paths.
+Use an internal bytes-first adapter with this order:
 
-Usage must be encapsulated and retain a fallback to the standard `json` library.
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
 
-### `msgspec`
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
 
-Evaluate `msgspec` for typed parsing of messages and tool calls with stable contracts.
+### Native streaming parser
 
-Expected benefits:
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
 
-- faster and more predictable parsing;
-- lower validation and conversion overhead;
-- lower memory usage for typed structures;
-- clearer detection of invalid payloads.
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
 
-It must not replace flexible parsing without compatibility tests using real payloads.
+### Async event loop
 
-### `uvloop`
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
 
-Evaluate `uvloop` as an optional event loop for the CLI and gateway on supported platforms.
+### Existing persistence and caches
 
-Expected benefits:
-
-- better asynchronous task scheduling;
-- lower latency for I/O operations;
-- higher throughput in highly concurrent scenarios;
-- better gateway responsiveness under load.
-
-`asyncio` remains the official fallback. Gains must be measured per operating system.
-
-## Other recommendations
-
-### Batched persistence
-
-Group the events from one round and persist them in a single SQLite transaction.
-
-Benefits:
-
-- fewer I/O operations;
-- lower transaction overhead;
-- lower session-save latency;
-- better efficiency in conversations with many messages.
-
-Ordering, role alternation, and crash recovery must remain intact.
-
-### Startup and tool discovery
-
-Separate metadata discovery from effective imports and cache schemas with versioning.
-
-Benefits:
-
-- lower cold-start time;
-- less repeated work when Hermes starts;
-- faster loading of tools and plugins;
-- fewer unnecessary imports.
-
-The cache must be invalidated when the version, configuration, skills, plugins, or tools change.
-
-### External metadata cache
-
-Use a local cache with TTL, a versioned schema, and atomic writes.
-
-Benefits:
-
-- fewer network calls;
-- faster responses for catalogs and metadata;
-- greater resilience when an external service is unavailable;
-- lower startup and query cost.
-
-Caches must never store secrets or sensitive data.
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
 
 ### Safe parallelism
 
-Run operations in parallel only when they are demonstrably independent.
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
 
-Benefits:
+## 3. Simplicio-derived candidates
 
-- lower total time for independent operations;
-- better use of I/O;
-- greater responsiveness in multi-tool flows;
-- less waiting caused by unnecessary sequential work.
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
 
-The implementation must preserve deterministic ordering, concurrency limits, timeouts, cancellation, and semantics equivalent to the sequential path.
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
 
-## How much can it improve
+## 4. Installation workflow
 
-The figures below are benchmark references from the former Hermes Turbo Agent fork. They are not guaranteed gains for current Hermes and must be reproduced on the real path before being treated as project results.
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
 
-| Measured path | Observed gain in fork benchmark |
-| --- | ---: |
-| JSON serialization with large payloads | approximately 4x–6x |
-| JSON deserialization with large payloads | approximately 4x |
-| Medium-message latency | approximately 3x |
-| Medium-message throughput | approximately 3x–4x |
-| Typed tool-call parsing | up to approximately 2x–5x, depending on method |
-| Batched session writes | approximately 19x–38x on the instrumented path |
-| Cached metadata queries | approximately 0.007 s per query in the measured scenario |
-| Startup and tool discovery | approximately 2x–4x in the measured scenario |
-| Subagent construction with dead local preflight | approximately 9x–10x on the specific measured path |
-| Parallel execution of independent operations | approximately 4x–5x in the measured scenario |
+## 5. Reproducible command pattern
 
-These values depend on payload, hardware, operating system, Python version, model, tool count, concurrent load, and the exact path measured. They must not be turned into a promise of “100x” for Hermes as a whole.
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
 
-## Expected general benefits
+An optional native build is allowed only after a baseline and only when the toolchain is available:
 
-- shorter startup time;
-- faster responses in multi-tool flows;
-- lower CPU and I/O cost;
-- higher message throughput;
-- lower memory use in typed structures;
-- better asynchronous scalability;
-- fewer repeated external calls;
-- native acceleration without sacrificing portability;
-- regression diagnosis with reproducible metrics.
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
 
-## How the skill works
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
 
-1. Map the project and active Hermes installation.
-2. Confirm branch, working state, and authorized scope.
-3. Measure cold start, warm start, tool discovery, persistence, parsing, and memory.
-4. Identify the dominant bottleneck.
-5. Apply one small change per cycle.
-6. Add a regression test and fallback.
-7. Run before/after benchmarks in the same environment.
-8. Reject the change if there is a functional, security, compatibility, or prompt-caching regression.
-9. Deliver a report, metrics, diff, and rollback instructions.
+## 6. Evidence and benchmarks
 
-## Compatibility guarantees
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
 
-- `orjson`, `msgspec`, and `uvloop` are optional;
-- standard `json` and `asyncio` remain available as fallbacks;
-- the system prompt and prompt-cache prefix remain stable during a conversation;
-- message role alternation is not changed;
-- behavioral settings stay in `config.yaml`;
-- no secrets are included in caches;
-- no external telemetry is added without opt-in;
-- publishable changes should be small and reviewable.
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
 
-## Conclusion
+## 7. Compatibility invariants
 
-Hermes Turbo Agent is an evidence-driven optimization strategy. The greatest benefit does not come from one library, but from combining less I/O, less startup work, more efficient parsing, correct caching, and safe parallelism.
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
 
-The goal is to make Hermes faster without turning it into an incompatible fork, requiring Rust or native dependencies, or sacrificing security, portability, or prompt-cache stability.
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.ar-SA.md
+++ b/READMEs/README.ar-SA.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Skill قابلة للتنفيذ لتثبيت Hermes Agent وتحسين أدائه. ليست fork قابلة للتنفيذ؛ بل تقيس نقاط الاختناق وتطبق تغييرات هيكلية صغيرة وقابلة للاختبار والتراجع.
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## التوصيات
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`: JSON أسرع مع fallback إلى `json`.
-- `msgspec`: parsing مكتوب للرسائل وtool calls ذات العقود المستقرة.
-- `uvloop`: event loop اختياري مع fallback إلى `asyncio`.
-- كتابة الجلسات على دفعات لتقليل I/O ومعاملات SQLite.
-- تسريع startup وtool discovery باستخدام cache بإصدار وإبطال صحيح.
-- cache للبيانات الوصفية الخارجية مع TTL وكتابة ذرية، من دون أسرار.
-- تنفيذ العمليات المستقلة بالتوازي فقط، مع ترتيب حتمي وحدود وtimeout وإلغاء.
+## 1. Scope and safety
 
-## الفوائد المتوقعة
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-أظهرت benchmarks السابقة للـ fork نحو 4–6x في JSON الكبير، و3–4x في مسار الرسائل، و19–38x في مسار الاستمرارية المقاس، و2–4x عند startup. هذه مراجع وليست ضمانات؛ يجب إعادة قياسها على Hermes الحقيقي.
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-يجب الحفاظ على prompt caching والتوافق وfallbacks الخاصة بـ Python/`asyncio` والأمان وrollback. راجع `README.md` و`SKILL.md`.
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.de-DE.md
+++ b/READMEs/README.de-DE.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Ausführbare Skill zur Installation und Leistungsoptimierung von Hermes Agent. Sie ist kein ausführbarer Fork: Sie misst Engpässe und wendet kleine, testbare und rücksetzbare Strukturänderungen an.
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## Empfehlungen
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`: schnelleres JSON mit Fallback auf `json`.
-- `msgspec`: typisiertes Parsing stabiler Nachrichten und Tool-Aufrufe.
-- `uvloop`: optionaler Event Loop mit Fallback auf `asyncio`.
-- Sitzungen stapelweise speichern, um I/O und SQLite-Transaktionen zu reduzieren.
-- Startup und Tool-Erkennung durch versionierten, korrekt invalidierten Cache beschleunigen.
-- Externe Metadaten mit TTL und atomarem Schreiben cachen, ohne Geheimnisse.
-- Unabhängige Operationen nur mit deterministischer Reihenfolge, Limits, Timeout und Abbruch parallelisieren.
+## 1. Scope and safety
 
-## Erwartete Vorteile
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-Frühere Fork-Benchmarks zeigten etwa 4–6x bei großem JSON, 3–4x im Nachrichtenpfad, 19–38x im gemessenen Persistenzpfad und 2–4x beim Startup. Das sind Referenzen, keine Garantien; sie müssen im echten Hermes reproduziert werden.
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-Prompt-Caching, Kompatibilität, Python/`asyncio`-Fallbacks, Sicherheit und Rollback müssen erhalten bleiben. Siehe `README.md` und `SKILL.md`.
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.es-ES.md
+++ b/READMEs/README.es-ES.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Skill ejecutable de instalación y optimización del rendimiento de Hermes Agent. No es un fork ejecutable: mide cuellos de botella y aplica cambios estructurales pequeños, comprobables y reversibles.
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## Recomendaciones
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`: JSON más rápido con fallback a `json`.
-- `msgspec`: parsing tipado de mensajes y llamadas de herramientas estables.
-- `uvloop`: event loop opcional con fallback a `asyncio`.
-- Escritura de sesiones por lotes para reducir I/O y transacciones SQLite.
-- Startup y descubrimiento de herramientas más rápidos con caché versionada e invalidación correcta.
-- Caché de metadatos externos con TTL y escritura atómica, sin secretos.
-- Paralelismo solo para operaciones independientes, con orden determinista, límites, timeout y cancelación.
+## 1. Scope and safety
 
-## Beneficios esperados
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-Benchmarks anteriores del fork observaron aproximadamente 4–6x en JSON grande, 3–4x en mensajes, 19–38x en el camino medido de persistencia y 2–4x en startup. Son referencias, no garantías: hay que reproducirlas en el Hermes real.
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-Deben conservarse prompt caching, compatibilidad, fallbacks Python/`asyncio`, seguridad y rollback. Consulta `README.md` y `SKILL.md`.
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.fr-FR.md
+++ b/READMEs/README.fr-FR.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Skill exécutable d’installation et d’optimisation des performances pour Hermes Agent. Ce n’est pas un fork exécutable : elle mesure les goulots d’étranglement et applique des changements structurels petits, testables et réversibles.
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## Recommandations
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson` : JSON plus rapide avec fallback vers `json`.
-- `msgspec` : parsing typé des messages et tool calls stables.
-- `uvloop` : event loop optionnelle avec fallback vers `asyncio`.
-- Écriture groupée des sessions pour réduire l’I/O et les transactions SQLite.
-- Startup et découverte des outils accélérés par un cache versionné et correctement invalidé.
-- Cache des métadonnées externes avec TTL et écriture atomique, sans secrets.
-- Paralléliser uniquement les opérations indépendantes, avec ordre déterministe, limites, timeout et annulation.
+## 1. Scope and safety
 
-## Bénéfices attendus
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-Les anciens benchmarks du fork indiquaient environ 4–6x pour le gros JSON, 3–4x pour les messages, 19–38x pour le chemin mesuré de persistance et 2–4x au démarrage. Ce sont des références, pas des garanties : il faut les reproduire dans Hermes.
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-Le prompt caching, la compatibilité, les fallbacks Python/`asyncio`, la sécurité et le rollback doivent être préservés. Voir `README.md` et `SKILL.md`.
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.he-IL.md
+++ b/READMEs/README.he-IL.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Skill הניתנת להרצה להתקנה ולאופטימיזציית ביצועים עבור Hermes Agent. זה אינו fork הניתן להרצה: היא מודדת צווארי בקבוק ומיישמת שינויים מבניים קטנים, ניתנים לבדיקה ולהחזרה.
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## המלצות
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`: JSON מהיר יותר עם fallback ל־`json`.
-- `msgspec`: parsing טיפוסי של הודעות ו־tool calls יציבים.
-- `uvloop`: event loop אופציונלי עם fallback ל־`asyncio`.
-- כתיבת sessions באצווה כדי לצמצם I/O ועסקאות SQLite.
-- האצת startup ו־tool discovery באמצעות cache עם גרסה וביטול תקין.
-- cache למטא־נתונים חיצוניים עם TTL וכתיבה אטומית, ללא secrets.
-- להקביל רק פעולות בלתי תלויות, תוך שמירה על סדר דטרמיניסטי, מגבלות, timeout וביטול.
+## 1. Scope and safety
 
-## יתרונות צפויים
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-Benchmarks קודמים של ה־fork הראו בערך 4–6x ב־JSON גדול, 3–4x בנתיב ההודעות, 19–38x בנתיב ההתמדה שנמדד ו־2–4x ב־startup. אלה ערכי ייחוס ולא הבטחות; יש לשחזר אותם ב־Hermes האמיתי.
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-יש לשמור על prompt caching, תאימות, fallbacks של Python/`asyncio`, אבטחה ו־rollback. ראו `README.md` ו־`SKILL.md`.
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.hi-IN.md
+++ b/READMEs/README.hi-IN.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Hermes Agent की स्थापना और performance optimization के लिए executable Skill। यह executable fork नहीं है: bottlenecks मापती है और छोटे, testable तथा reversible structural बदलाव लागू करती है।
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## सिफारिशें
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`: `json` fallback के साथ तेज़ JSON।
-- `msgspec`: स्थिर messages और tool calls के लिए typed parsing।
-- `uvloop`: `asyncio` fallback वाला optional event loop।
-- I/O और SQLite transactions घटाने के लिए sessions को batch में लिखना।
-- versioned cache और सही invalidation से startup और tool discovery तेज़ करना।
-- TTL और atomic writes वाला external-metadata cache; secrets कभी न रखें।
-- केवल independent operations को deterministic order, limits, timeout और cancellation के साथ parallel करना।
+## 1. Scope and safety
 
-## अपेक्षित लाभ
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-पिछले fork benchmarks में बड़े JSON पर लगभग 4–6x, message path पर 3–4x, measured persistence path पर 19–38x और startup पर 2–4x देखा गया। ये references हैं, guarantees नहीं; वास्तविक Hermes path पर इन्हें दोहराना होगा।
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-prompt caching, compatibility, Python/`asyncio` fallbacks, security और rollback सुरक्षित रहने चाहिए। `README.md` और `SKILL.md` देखें।
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.id-ID.md
+++ b/READMEs/README.id-ID.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Skill yang dapat dijalankan untuk instalasi dan optimasi performa Hermes Agent. Ini bukan fork yang dapat dijalankan: skill ini mengukur bottleneck dan menerapkan perubahan struktural yang kecil, dapat diuji, dan dapat dibatalkan.
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## Rekomendasi
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`: JSON lebih cepat dengan fallback ke `json`.
-- `msgspec`: parsing bertipe untuk pesan dan tool call yang stabil.
-- `uvloop`: event loop opsional dengan fallback ke `asyncio`.
-- Penulisan sesi secara batch untuk mengurangi I/O dan transaksi SQLite.
-- Startup dan penemuan tool lebih cepat dengan cache berversi dan invalidasi yang benar.
-- Cache metadata eksternal dengan TTL dan penulisan atomik, tanpa secrets.
-- Paralelkan hanya operasi independen dengan urutan deterministik, batas, timeout, dan pembatalan.
+## 1. Scope and safety
 
-## Manfaat yang diharapkan
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-Benchmark fork sebelumnya mengamati sekitar 4–6x pada JSON besar, 3–4x pada jalur pesan, 19–38x pada jalur persistensi yang diukur, dan 2–4x pada startup. Ini referensi, bukan jaminan; pengukuran harus diulang pada Hermes nyata.
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-Prompt caching, kompatibilitas, fallback Python/`asyncio`, keamanan, dan rollback harus dipertahankan. Lihat `README.md` dan `SKILL.md`.
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.it-IT.md
+++ b/READMEs/README.it-IT.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Skill eseguibile per l’installazione e l’ottimizzazione delle prestazioni di Hermes Agent. Non è un fork eseguibile: misura i colli di bottiglia e applica modifiche strutturali piccole, verificabili e reversibili.
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## Raccomandazioni
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`: JSON più veloce con fallback a `json`.
-- `msgspec`: parsing tipizzato di messaggi e tool call stabili.
-- `uvloop`: event loop opzionale con fallback a `asyncio`.
-- Scrittura batch delle sessioni per ridurre I/O e transazioni SQLite.
-- Startup e scoperta degli strumenti più rapidi con cache versionata e invalidazione corretta.
-- Cache dei metadati esterni con TTL e scrittura atomica, senza segreti.
-- Parallelizzare solo operazioni indipendenti, con ordine deterministico, limiti, timeout e cancellazione.
+## 1. Scope and safety
 
-## Benefici attesi
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-I benchmark precedenti del fork hanno osservato circa 4–6x sul JSON grande, 3–4x nel percorso dei messaggi, 19–38x nel percorso misurato della persistenza e 2–4x nello startup. Sono riferimenti, non garanzie: le misure vanno riprodotte su Hermes reale.
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-Prompt caching, compatibilità, fallback Python/`asyncio`, sicurezza e rollback devono essere preservati. Consulta `README.md` e `SKILL.md`.
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.ja-JP.md
+++ b/READMEs/README.ja-JP.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Hermes Agent のインストールと性能最適化を行う実行可能な Skill です。実行可能な fork ではなく、ボトルネックを測定し、小さくテスト可能で元に戻せる構造変更を適用します。
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## 推奨事項
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`: `json` fallback 付きの高速 JSON。
-- `msgspec`: 安定したメッセージと tool call の型付き parsing。
-- `uvloop`: `asyncio` fallback 付きの任意 event loop。
-- セッションをまとめて SQLite に保存し、I/O とトランザクションを削減。
-- versioned cache と正しい無効化で startup と tool discovery を高速化。
-- TTL と atomic write を使う外部メタデータ cache。秘密情報は保存しない。
-- 独立した処理だけを決定的な順序、上限、timeout、キャンセル付きで並列化。
+## 1. Scope and safety
 
-## 期待される効果
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-過去の fork ベンチマークでは、大きな JSON で約 4–6 倍、メッセージ経路で 3–4 倍、測定した永続化経路で 19–38 倍、startup で 2–4 倍でした。保証ではなく参考値なので、実際の Hermes で再測定します。
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-prompt caching、互換性、Python/`asyncio` fallback、安全性、rollback を維持します。詳細は `README.md` と `SKILL.md` を参照してください。
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.ko-KR.md
+++ b/READMEs/README.ko-KR.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Hermes Agent의 설치 및 성능 최적화를 위한 실행 가능한 Skill입니다. 실행 가능한 fork가 아니라 병목을 측정하고 작고 테스트 가능하며 되돌릴 수 있는 구조 변경을 적용합니다.
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## 권장 사항
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`: `json` fallback을 제공하는 더 빠른 JSON.
-- `msgspec`: 안정적인 메시지와 tool call의 타입 기반 parsing.
-- `uvloop`: `asyncio` fallback을 제공하는 선택적 event loop.
-- 세션을 일괄 저장하여 I/O와 SQLite 트랜잭션을 줄입니다.
-- 버전이 있는 cache와 올바른 무효화로 startup과 tool discovery를 가속합니다.
-- TTL과 atomic write를 사용하는 외부 메타데이터 cache. 비밀은 저장하지 않습니다.
-- 독립 작업만 결정적 순서, 제한, timeout, 취소를 유지하며 병렬화합니다.
+## 1. Scope and safety
 
-## 기대 효과
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-이전 fork 벤치마크에서는 큰 JSON 약 4–6배, 메시지 경로 3–4배, 측정된 persistence 경로 19–38배, startup 2–4배가 관찰되었습니다. 보장이 아니라 참고값이므로 실제 Hermes에서 재현해야 합니다.
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-prompt caching, 호환성, Python/`asyncio` fallback, 보안 및 rollback을 보존해야 합니다. `README.md`와 `SKILL.md`를 참조하세요.
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.ms-MY.md
+++ b/READMEs/README.ms-MY.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Skill boleh laku untuk pemasangan dan pengoptimuman prestasi Hermes Agent. Ia bukan fork boleh laku: ia mengukur bottleneck dan menggunakan perubahan struktur yang kecil, boleh diuji dan boleh dipulihkan.
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## Cadangan
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`: JSON lebih pantas dengan fallback kepada `json`.
-- `msgspec`: parsing bertype untuk mesej dan tool call yang stabil.
-- `uvloop`: event loop pilihan dengan fallback kepada `asyncio`.
-- Menulis sesi secara kelompok untuk mengurangkan I/O dan transaksi SQLite.
-- Startup dan penemuan alat lebih pantas dengan cache berversi serta invalidasi yang betul.
-- Cache metadata luaran dengan TTL dan penulisan atomik, tanpa secrets.
-- Selarikan hanya operasi bebas, dengan susunan deterministik, had, timeout dan pembatalan.
+## 1. Scope and safety
 
-## Faedah yang dijangka
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-Benchmark fork terdahulu menunjukkan kira-kira 4–6x untuk JSON besar, 3–4x pada laluan mesej, 19–38x pada laluan persistence yang diukur dan 2–4x ketika startup. Ini rujukan, bukan jaminan; ukuran mesti diulang pada Hermes sebenar.
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-Prompt caching, keserasian, fallback Python/`asyncio`, keselamatan dan rollback mesti dikekalkan. Lihat `README.md` dan `SKILL.md`.
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.pl-PL.md
+++ b/READMEs/README.pl-PL.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Wykonywalny skill do instalacji i optymalizacji wydajności Hermes Agent. To nie jest wykonywalny fork: mierzy wąskie gardła i stosuje małe, testowalne oraz odwracalne zmiany strukturalne.
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## Zalecenia
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`: szybszy JSON z fallbackiem do `json`.
-- `msgspec`: typowane parsing wiadomości i stabilnych wywołań narzędzi.
-- `uvloop`: opcjonalny event loop z fallbackiem do `asyncio`.
-- Grupowy zapis sesji w celu ograniczenia I/O i transakcji SQLite.
-- Szybszy startup i wykrywanie narzędzi dzięki wersjonowanemu cache z poprawną invalidacją.
-- Cache zewnętrznych metadanych z TTL i zapisem atomowym, bez sekretów.
-- Równoległość tylko dla niezależnych operacji, z deterministyczną kolejnością, limitami, timeoutem i anulowaniem.
+## 1. Scope and safety
 
-## Oczekiwane korzyści
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-Wcześniejsze benchmarki forka wykazały około 4–6x dla dużego JSON, 3–4x dla ścieżki wiadomości, 19–38x dla zmierzonej ścieżki utrwalania i 2–4x podczas startupu. To wartości referencyjne, nie gwarancje; pomiary trzeba powtórzyć na rzeczywistym Hermes.
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-Należy zachować prompt caching, kompatybilność, fallbacki Python/`asyncio`, bezpieczeństwo i rollback. Zobacz `README.md` i `SKILL.md`.
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.pt-BR.md
+++ b/READMEs/README.pt-BR.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Skill executável de instalação e otimização de desempenho para o Hermes Agent. Ela não é um fork executável: mede gargalos e aplica mudanças estruturais pequenas, testáveis e reversíveis.
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## Recomendações
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`: JSON mais rápido com fallback para `json`.
-- `msgspec`: parsing tipado de mensagens e tool calls estáveis.
-- `uvloop`: event loop opcional com fallback para `asyncio`.
-- Escrita de sessões em lote para reduzir I/O e transações SQLite.
-- Startup e descoberta de ferramentas mais rápidos com cache versionado e invalidação correta.
-- Cache de metadados externos com TTL e escrita atômica, sem segredos.
-- Paralelismo apenas para operações independentes, com ordem determinística, limites, timeout e cancelamento.
+## 1. Scope and safety
 
-## Benefícios esperados
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-Benchmarks anteriores do fork observaram aproximadamente 4–6x em JSON grande, 3–4x no caminho de mensagens, 19–38x no caminho medido de persistência e 2–4x no startup. São referências, não garantias; é preciso reproduzir as medições no Hermes real.
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-Prompt caching, compatibilidade, fallbacks Python/`asyncio`, segurança e rollback devem ser preservados. Consulte `README.md` e `SKILL.md`.
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.ru-RU.md
+++ b/READMEs/README.ru-RU.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-Исполняемая skill для установки и оптимизации производительности Hermes Agent. Это не исполняемый fork: она измеряет узкие места и применяет небольшие, проверяемые и обратимые структурные изменения.
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## Рекомендации
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`: более быстрый JSON с fallback на `json`.
-- `msgspec`: типизированный parsing стабильных сообщений и tool calls.
-- `uvloop`: необязательный event loop с fallback на `asyncio`.
-- Пакетная запись сессий для снижения I/O и числа транзакций SQLite.
-- Ускорение startup и tool discovery через версионированный cache с корректной инвалидацией.
-- Cache внешних метаданных с TTL и atomic write, без секретов.
-- Параллелить только независимые операции, сохраняя детерминированный порядок, лимиты, timeout и отмену.
+## 1. Scope and safety
 
-## Ожидаемый эффект
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-Предыдущие benchmark-и fork показали примерно 4–6x для большого JSON, 3–4x для пути сообщений, 19–38x для измеренного пути сохранения и 2–4x для startup. Это ориентиры, а не гарантии; измерения нужно повторить в Hermes.
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-Необходимо сохранить prompt caching, совместимость, fallback Python/`asyncio`, безопасность и rollback. Подробности: `README.md` и `SKILL.md`.
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/READMEs/README.zh-CN.md
+++ b/READMEs/README.zh-CN.md
@@ -1,19 +1,122 @@
 # Hermes Turbo Agent
 
-用于 Hermes Agent 安装与性能优化的可执行 Skill。它不是可执行 fork，而是先测量瓶颈，再应用小型、可测试且可回滚的结构性修改。
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.de-DE.md">🇩🇪 Deutsch</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a>
+</p>
 
-## 建议
+Executable installation and performance-optimization skill for Hermes Agent. It is a procedure, not an executable fork: it measures the active Hermes path, applies the smallest compatible change, tests it, and keeps it only when evidence supports it.
 
-- `orjson`：更快的 JSON，并保留 `json` fallback。
-- `msgspec`：用于稳定消息和 tool call 的类型化 parsing。
-- `uvloop`：可选 event loop，并保留 `asyncio` fallback。
-- 批量写入会话，减少 I/O 和 SQLite 事务。
-- 使用版本化 cache 并正确失效，加速 startup 和 tool discovery。
-- 使用 TTL 与 atomic write 缓存外部元数据，不保存 secrets。
-- 仅并行执行独立操作，并保持确定性顺序、限制、timeout 和取消语义。
+## 1. Scope and safety
 
-## 预期收益
+The target is the active bundle at `${HERMES_HOME:-$HOME/.hermes}`. The skill must not silently modify a source checkout, discard user state, break prompt caching, add telemetry, or claim a benchmark gain that was not measured on the real path.
 
-旧 fork 的 benchmark 在大型 JSON 上约提升 4–6 倍，消息路径 3–4 倍，实测持久化路径 19–38 倍，startup 2–4 倍。这些只是参考而非保证，必须在真实 Hermes 路径上复现。
+Every run creates a rollback point, records a baseline, applies a bounded change, runs regression tests, repeats the benchmark, and reports modified files, fallback status, and rollback instructions.
 
-必须保留 prompt caching、兼容性、Python/`asyncio` fallback、安全性和 rollback。请参阅 `README.md` 与 `SKILL.md`。
+## 2. Performance modules
+
+### Fast JSON and typed contracts
+
+Use an internal bytes-first adapter with this order:
+
+1. `orjson` for ordinary JSON dictionaries, lists, tool results, and cache payloads;
+2. `msgspec` only for stable typed `Struct` contracts such as fixed envelopes;
+3. Python `json` as the universal fallback.
+
+The adapter must preserve `str`/`bytes` behavior, Unicode, invalid-payload errors, non-serializable values, and compatibility with existing dictionaries. It must never replace flexible parsing with a typed contract without tests.
+
+### Native streaming parser
+
+The Simplicio Agent comparison added a PyO3 `hermes_fast` extension for incremental JSON/tool-call parsing. Hermes Turbo may build it with `maturin`, but it remains optional and must have a `json.JSONDecoder.raw_decode` fallback.
+
+The FFI boundary is not free. On the measured macOS Python 3.11 path, small payloads were faster with stdlib; payloads around 1 KiB and larger favored Rust. Use a target-specific size threshold and re-benchmark after changing Python, Rust, or the extension.
+
+### Async event loop
+
+Install `uvloop` only on supported Unix platforms and only through capability detection at async entrypoints. Keep stdlib `asyncio` for Windows, missing packages, opt-out, and installation failures. Measure cold start, warm start, latency, and throughput separately.
+
+### Existing persistence and caches
+
+Batch one conversation round into one SQLite transaction without changing message ordering, role alternation, or crash recovery. Cache tool discovery, schemas, and external metadata with versioning, TTL where appropriate, invalidation on configuration/skill/plugin/schema changes, atomic writes, and no secrets.
+
+### Safe parallelism
+
+Parallelize only independent operations. Preserve deterministic result order, bounded concurrency, timeout, cancellation, backpressure, and sequential-equivalent semantics.
+
+## 3. Simplicio-derived candidates
+
+The analyzed `wesleysimplicio/simplicio-agent` repository also contains a warm daemon, working-set/token memoization, deterministic routing, an async DAG executor, an HTTP pool, a TOON output codec, project mapping, and a performance-regression gate.
+
+Working-set memoization and cache invalidation are safe candidates when the active Hermes path does not already provide them. The warm daemon is a separate lifecycle surface: do not copy it into Hermes without a daemon benchmark, idle TTL, memory bound, shutdown handling, and crash-recovery tests. The Rust token estimator is not enabled automatically because serialization and FFI can outweigh its simple arithmetic; benchmark it on the actual history shape first.
+
+## 4. Installation workflow
+
+1. Map the active bundle, runtime, profile, package manager, and state.
+2. Create a rollback archive before mutation.
+3. Capture cold/warm startup, discovery, persistence, JSON/tool parsing, async throughput, and memory baselines.
+4. Detect platform and optional capabilities.
+5. Install `orjson`, `msgspec`, and `uvloop` with the active runtime package manager (`uv pip` when the venv has no pip).
+6. Apply one small, reviewable change to the measured bottleneck.
+7. Add regression, fallback, invalid-payload, concurrency, and crash-recovery coverage.
+8. Run the same benchmark in the same environment.
+9. Keep the change only if tests pass and there is no compatibility, safety, memory, latency, or prompt-cache regression.
+10. Write a report with packages, files, metrics, tests, fallbacks, and rollback.
+
+## 5. Reproducible command pattern
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_RUNTIME="$HERMES_HOME/hermes-agent/venv/bin/python"
+uv pip install --python "$HERMES_RUNTIME" orjson msgspec
+# Supported Unix platforms only:
+uv pip install --python "$HERMES_RUNTIME" uvloop
+```
+
+An optional native build is allowed only after a baseline and only when the toolchain is available:
+
+```bash
+cd "$HERMES_HOME/hermes-agent/rust_ext"
+source "$HERMES_HOME/hermes-agent/venv/bin/activate"
+uvx --from maturin maturin develop --release
+```
+
+Do not use `uv add` or modify the source checkout's dependency manifest for an active-bundle installation.
+
+## 6. Evidence and benchmarks
+
+Reference numbers from another operating system or fork are not Hermes results. The report must store before/after artifacts under the active bundle and identify the exact payload, Python version, platform, iteration count, and backend.
+
+A local result may be useful without being universal. In the macOS implementation, the measured result was approximately 2.1× for JSON decode through `fast_json`/orjson and 2.7× for a 4 KiB tool-call parser through thresholded `hermes_fast`; small parser payloads correctly remained on stdlib.
+
+## 7. Compatibility invariants
+
+- Keep the system prompt and prompt-cache prefix byte-stable during a conversation.
+- Never insert synthetic messages or break strict role alternation.
+- Preserve Python `json` and `asyncio` fallbacks.
+- Keep settings in `config.yaml` and secrets in `.env`.
+- Never cache secrets or add outbound telemetry without explicit opt-in.
+- Preserve plugins, providers, skills, security boundaries, and external payload semantics.
+- Do not force native dependencies on constrained platforms.
+- Do not report an optimization as complete without tests, measured comparison, and rollback evidence.
+
+## 8. Related files
+
+- [`SKILL.md`](SKILL.md) — executable installation and optimization procedure.
+- [`READMEs/`](READMEs/) — localized copies with this same section structure.
+
+The goal is faster Hermes without creating an incompatible fork: less repeated work, faster parsing where it actually wins, controlled async scheduling, bounded persistence, and evidence-driven decisions.

--- a/SKILL.md
+++ b/SKILL.md
@@ -10,7 +10,7 @@ metadata:
     related_skills: [hermes-agent-skill-authoring, systematic-debugging]
 ---
 
-# Hermes Turbo Agent
+# Hermes Turbo Agent 10x
 
 ## Purpose
 
@@ -27,22 +27,23 @@ Execute these steps in order when this skill is requested for installation or sp
 3. Create a rollback point for bundle configuration and skills. Never overwrite unrelated user state.
 4. Capture a baseline for installed-runtime cold start, warm start, tool discovery, session persistence, JSON/tool-call parsing, async throughput, and memory. Store results under the active bundle, not in the source repository.
 5. Detect platform and capabilities.
-6. Install optional dependencies into the active Hermes environment, using the installed runtime package manager:
+6. Install optional dependencies into the active Hermes environment, using the project's package manager:
    - `orjson`
    - `msgspec`
    - `uvloop` on supported Unix platforms only
    Keep Python `json` and `asyncio` fallbacks available.
-7. Apply the smallest compatible bundle-level changes for the measured bottleneck:
+7. Apply the smallest compatible code changes for the measured bottleneck:
    - use an internal fast-JSON adapter with `orjson` fallback;
-   - use `msgspec` only for stable typed message/tool-call contracts;
-   - enable `uvloop` only through capability detection;
+   - use bytes-first serialization and `msgspec` only for stable typed message/tool-call contracts;
+   - enable `uvloop` only through capability detection at async entrypoints;
+   - optionally build the PyO3 `hermes_fast` extension for streaming JSON/tool-call parsing;
    - batch session writes into one SQLite transaction per round;
    - cache tool discovery, schemas, and external metadata with versioning, TTL, atomic writes, and invalidation;
    - parallelize only independent operations with deterministic ordering, limits, timeouts, and cancellation.
 8. Add or update regression tests and verify crash recovery, concurrency, invalid payloads, plugin/provider compatibility, and fallback paths.
 9. Run the same benchmarks again in the same environment.
 10. Keep a change only when functional tests pass and the measured path improves without a safety, compatibility, memory, or latency regression.
-11. Produce a report containing installed packages, modified bundle files, benchmark before/after, tests, fallback status, and rollback instructions.
+11. Produce a report containing installed packages, modified files, benchmark before/after, tests, fallback status, and rollback instructions.
 
 ## Required command patterns
 
@@ -56,13 +57,33 @@ uv pip install --python "$HERMES_RUNTIME" orjson msgspec
 uv pip install --python "$HERMES_RUNTIME" uvloop
 ```
 
-Do not run `uv add` or modify `pyproject.toml` in the Hermes source checkout for this installed-bundle task. If the installed runtime or `uv` is missing, stop and report the missing prerequisite rather than installing into system Python. If an optional package fails, retain the fallback path, document the failure, and continue only with safe bundle-level changes.
+Do not run `uv add` or modify `pyproject.toml` in the Hermes source checkout for this installed-bundle task. If the installed runtime is missing, stop and report the missing prerequisite rather than installing into system Python. If an optional package fails, retain the fallback path, document the failure, and continue only with safe bundle-level changes.
+
+For an installed runtime without `pip`, use `uv pip` as shown above. Do not create a new project environment merely to run the installer.
+
+### Simplicio-derived performance modules
+
+When the installed bundle contains the corresponding Hermes modules, prefer these additive paths discovered in `wesleysimplicio/simplicio-agent`:
+
+| Module | Benefit | Safe fallback | Gate |
+|---|---|---|---|
+| `agent._fastjson` | bytes-first `orjson`, then `msgspec`, then stdlib | `json` | round-trip, bytes/str, Unicode and invalid-payload tests |
+| `agent._hermes_fast` + `hermes_fast` | Rust incremental tool-call JSON parsing | `json.JSONDecoder.raw_decode` | build/import probe and parser equivalence test |
+| `agent.uvloop_utils` | lower async scheduling overhead on supported Unix | stdlib `asyncio` | platform, opt-out and loop-policy test |
+| warm daemon | amortizes plugin/skill/provider discovery across invocations | ordinary cold start | only enable after a real daemon lifecycle benchmark |
+| working-set/token cache | reduces repeated context scoring and serialization | existing estimator | identity/invalidation and memory-bound tests |
+
+The Rust estimator is **not automatically preferable**: FFI and serialization can outweigh its trivial arithmetic. Route only the parser through Rust by default; benchmark token estimation before enabling `HERMES_RUST_ESTIMATES=1`.
+
+For Rust parser dispatch, benchmark payload sizes on the target machine and use a size threshold when the FFI crossing loses on small payloads. Never report the upstream Linux result as a macOS result.
+
+The warm daemon is a separate process and must not be added by copying a whole fork. Reuse existing gateway/session lifecycle code, bound idle TTL and memory, and prove crash recovery before enabling it.
 
 ## Implementation requirements
 
 ### `orjson`
 
-Encapsulate JSON acceleration behind an internal adapter in the installed bundle. Verify bytes versus strings, dates, exceptions, non-serializable objects, and all real payload shapes. Never replace the standard fallback without tests.
+Encapsulate JSON acceleration behind an internal adapter. Verify bytes versus strings, dates, exceptions, non-serializable objects, and all real payload shapes. Never replace the standard fallback without tests.
 
 ### `msgspec`
 
@@ -83,18 +104,20 @@ Batch SQLite writes without changing message ordering or role alternation. Versi
 - Preserve Python and `asyncio` fallbacks.
 - Put behavioral settings in `config.yaml`; keep secrets in `.env`.
 - Do not add outbound telemetry without explicit opt-in.
-- Do not discard user state, force-push, delete branches, or rewrite history.
-- Do not claim a benchmark gain that was not measured on the actual installed path.
+- Do not discard user changes, force-push, delete branches, or rewrite history.
+- Do not claim a benchmark gain that was not measured on the actual path.
 
 ## Acceptance criteria
 
 - Baseline and post-change benchmarks are reproducible and comparable.
-- `orjson`, `msgspec`, and `uvloop` installation status is verified in the active bundle runtime.
+- `orjson`, `msgspec`, and `uvloop` installation status is verified.
+- If a native extension is built, its exact platform/Python wheel and import status are verified; otherwise the Python parser fallback is tested.
 - Unit and real-path E2E tests pass.
 - Fallback paths are tested without optional dependencies.
+- Token-estimator acceleration is kept off unless its real-path benchmark beats Python without changing estimates.
 - Configuration, plugins, skills, providers, security, prompt caching, and message alternation remain compatible.
 - The diff is reviewable and rollback is documented.
 
 ## Version control
 
-If the user explicitly requests publication, create a branch, commit the verified skill/documentation changes, push that branch, open a PR against the requested base, wait for checks, and merge only when the PR is mergeable. Never push directly to `main` when a PR is requested.
+If the user explicitly requests publication, create a branch, commit the verified changes, push that branch, open a PR against the requested base, wait for checks, and merge only when the PR is mergeable. Never push directly to `main` when a PR is requested.


### PR DESCRIPTION
## Summary
- update `SKILL.md` to version 2.1.0 with the Simplicio Agent performance findings
- document fast JSON, typed `msgspec`, conditional `uvloop`, optional `hermes_fast`, FFI thresholds, fallbacks, and benchmark gates
- synchronize the English README and all localized README files to one canonical section structure

## Validation
- `git diff --check`
- all 16 README files have identical structure and content hash
- skill version and required performance sections validated
- no GitHub Actions workflow was triggered or monitored

## Release
This PR is intended for release `v2.1.0` after merge.
